### PR TITLE
Improve AddEtapa validation

### DIFF
--- a/DelCorp.Tests/DelCorp.Tests.csproj
+++ b/DelCorp.Tests/DelCorp.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DelCorp.csproj" />
+  </ItemGroup>
+</Project>

--- a/DelCorp.Tests/ManageBudgetViewModelTests.cs
+++ b/DelCorp.Tests/ManageBudgetViewModelTests.cs
@@ -1,0 +1,67 @@
+using System.Threading.Tasks;
+using DelCorp.ViewModels;
+using DelCorp.Services;
+using DelCorp.Models;
+using Xunit;
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Controls;
+
+namespace DelCorp.Tests;
+
+public class ManageBudgetViewModelTests
+{
+    private class StubDataService : IDataService
+    {
+        public Task<List<Project>> GetProjects() => Task.FromResult(new List<Project>());
+        public Task<List<Project>> GetPagedProjects(int page, int pageSize) => Task.FromResult(new List<Project>());
+        public Task<Project> GetProject(int id) => Task.FromResult(new Project());
+        public Task<bool> SaveProject(Project project) => Task.FromResult(true);
+        public Task<bool> DeleteProject(int id) => Task.FromResult(true);
+        public Task<bool> SyncProjects() => Task.FromResult(true);
+        public Task<IEnumerable<Presupuesto>> GetPresupuestosByProjectId(int projectId) => Task.FromResult<IEnumerable<Presupuesto>>(new List<Presupuesto>());
+        public Task<IEnumerable<Presupuesto>> GetAllPresupuestos() => Task.FromResult<IEnumerable<Presupuesto>>(new List<Presupuesto>());
+        public Task<bool> DeletePresupuesto(long presupuestoId) => Task.FromResult(true);
+        public Task<IEnumerable<Etapa>> GetEtapasByPresupuestoId(int presupuestoId) => Task.FromResult<IEnumerable<Etapa>>(new List<Etapa>());
+        public Task<Etapa> SaveEtapa(Etapa etapa) => Task.FromResult(etapa);
+        public Task DeleteEtapa(long etapaId) => Task.CompletedTask;
+        public Task<Presupuesto> SavePresupuesto(Presupuesto presupuesto) => Task.FromResult(presupuesto);
+        public Task<IEnumerable<SubEtapa>> GetSubEtapasByEtapaId(long etapaId) => Task.FromResult<IEnumerable<SubEtapa>>(new List<SubEtapa>());
+        public Task SaveSubEtapa(SubEtapa subEtapa) => Task.CompletedTask;
+        public Task<SubEtapa> GetSubEtapaByIdAsync(long subEtapaId) => Task.FromResult(new SubEtapa());
+        public Task<IEnumerable<CategoriaRec>> GetCategoriasRecAsync() => Task.FromResult<IEnumerable<CategoriaRec>>(new List<CategoriaRec>());
+        public Task SaveCategoriaRecAsync(CategoriaRec categoria) => Task.CompletedTask;
+        public Task<IEnumerable<UniMedRe>> GetUniMedReAsync() => Task.FromResult<IEnumerable<UniMedRe>>(new List<UniMedRe>());
+        public Task SaveUniMedReAsync(UniMedRe uniMedRe) => Task.CompletedTask;
+        public Task<IEnumerable<Recurso>> GetRecursosAsync(long? idCategoriaRec = null) => Task.FromResult<IEnumerable<Recurso>>(new List<Recurso>());
+        public Task SaveRecursoAsync(Recurso recurso) => Task.CompletedTask;
+        public Task<IEnumerable<RecursoUti>> GetRecursosUtiBySubEtapaIdAsync(long subEtapaId) => Task.FromResult<IEnumerable<RecursoUti>>(new List<RecursoUti>());
+        public Task<RecursoUti> SaveRecursoUtiAsync(RecursoUti recursoUti) => Task.FromResult(recursoUti);
+        public Task DeleteRecursoUtiAsync(long recursoUtiId) => Task.CompletedTask;
+        public Task<IEnumerable<CategoriaActividad>> GetCategoriasActividadAsync() => Task.FromResult<IEnumerable<CategoriaActividad>>(new List<CategoriaActividad>());
+        public Task SaveCategoriaActividadAsync(CategoriaActividad categoriaActividad) => Task.CompletedTask;
+        public Task<IEnumerable<Actividad>> GetActividadesAsync(long? categoriaActividadId = null, string searchText = null) => Task.FromResult<IEnumerable<Actividad>>(new List<Actividad>());
+        public Task<Actividad> GetActividadByIdAsync(long actividadId) => Task.FromResult(new Actividad());
+        public Task<Actividad> SaveActividadAsync(Actividad actividad) => Task.FromResult(actividad);
+    }
+
+    [Fact]
+    public async Task AddEtapa_InvalidNumeroEtapa_DoesNotThrow()
+    {
+        var service = new StubDataService();
+        var vm = new ManageBudgetViewModel(service)
+        {
+            CurrentPresupuesto = new Presupuesto { Id = 1 },
+            ActividadEtapa = "foo",
+            CantidadEtapa = 1,
+            NumeroEtapa = "invalid"
+        };
+
+        Application.Current ??= new Application();
+        Shell.SetCurrent(new Shell());
+
+        var ex = await Record.ExceptionAsync(() => vm.AddEtapaCommand.ExecuteAsync(null));
+        Assert.Null(ex);
+        Assert.Empty(vm.Etapas);
+    }
+}

--- a/DelCorp.sln
+++ b/DelCorp.sln
@@ -5,19 +5,25 @@ VisualStudioVersion = 17.13.35913.81 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DelCorp", "DelCorp.csproj", "{B0AB1061-2985-4B6A-86BD-02C07A53C91B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DelCorp.Tests", "DelCorp.Tests\DelCorp.Tests.csproj", "{013DB462-8C45-4771-B9C2-69B8C09290B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Release|Any CPU.Deploy.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+                {B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B0AB1061-2985-4B6A-86BD-02C07A53C91B}.Release|Any CPU.Deploy.0 = Release|Any CPU
+                {013DB462-8C45-4771-B9C2-69B8C09290B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {013DB462-8C45-4771-B9C2-69B8C09290B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {013DB462-8C45-4771-B9C2-69B8C09290B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {013DB462-8C45-4771-B9C2-69B8C09290B9}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/ViewModels/ManageBudgetViewModel.cs
+++ b/ViewModels/ManageBudgetViewModel.cs
@@ -132,10 +132,16 @@ public partial class ManageBudgetViewModel : ObservableObject, IQueryAttributabl
             return;
         }
 
+        if (!int.TryParse(NumeroEtapa, out var numeroEtapaValue))
+        {
+            await Shell.Current.DisplayAlert("Error", "Número de etapa inválido", "OK");
+            return;
+        }
+
         // Crear nueva etapa
         var nuevaEtapa = new Etapa
         {
-            NumeroEtapa = int.Parse(NumeroEtapa),
+            NumeroEtapa = numeroEtapaValue,
             //ActividadEtapa = ActividadEtapa,
             //UnidadMedida = UnidadMedida,
             CantidadEtapa = CantidadEtapa,


### PR DESCRIPTION
## Summary
- parse `NumeroEtapa` via `int.TryParse`
- show alert and return if parsing fails
- add xUnit test project with a unit test covering invalid `NumeroEtapa`
- include new test project in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d1c44a5c832b88314771d4cdd746