### PR TITLE
Add resource usage tracking

### DIFF
--- a/Models/Local/LocalRegistroRecursoUti.cs
+++ b/Models/Local/LocalRegistroRecursoUti.cs
@@ -1,0 +1,21 @@
+using SQLite;
+
+namespace DelCorp.Models.Local;
+
+[Table("RegistroRecursosUti")]
+public class LocalRegistroRecursoUti
+{
+    [PrimaryKey, AutoIncrement]
+    public long LocalId { get; set; }
+    public long? ServerId { get; set; }
+    [Indexed]
+    public System.DateTime CreatedAt { get; set; }
+    public System.DateTime? FechaRecursoUti { get; set; }
+    public decimal? CantidadRecursosUti { get; set; }
+    public decimal? PrecioUniRecursosUti { get; set; }
+    public decimal? TotalRecursosUti { get; set; }
+    public long? IdRecurso { get; set; }
+    public long? IdSubEtapa { get; set; }
+    public long? IdUniMedida { get; set; }
+    public bool IsSynced { get; set; }
+}

--- a/Models/RegistroRecursoUti.cs
+++ b/Models/RegistroRecursoUti.cs
@@ -1,0 +1,17 @@
+namespace DelCorp.Models;
+
+public class RegistroRecursoUti
+{
+    public long Id { get; set; }
+    public System.DateTime CreatedAt { get; set; }
+    public System.DateTime? FechaRecursoUti { get; set; }
+    public decimal? CantidadRecursosUti { get; set; }
+    public decimal? PrecioUniRecursosUti { get; set; }
+    public decimal? TotalRecursosUti { get; set; }
+    public long? IdRecurso { get; set; }
+    public long? IdSubEtapa { get; set; }
+    public long? IdUniMedida { get; set; }
+    public Recurso Recurso { get; set; }
+    public SubEtapa SubEtapa { get; set; }
+    public UniMedRe UniMedRe { get; set; }
+}

--- a/Models/Supabase/SupabaseRegistroRecursoUti.cs
+++ b/Models/Supabase/SupabaseRegistroRecursoUti.cs
@@ -1,0 +1,35 @@
+using Postgrest.Attributes;
+using Postgrest.Models;
+
+namespace DelCorp.Models.Supabase;
+
+[Table("registro_recursos_uti")]
+public class SupabaseRegistroRecursoUti : BaseModel
+{
+    [PrimaryKey("id_registro_recurso_uti", false)]
+    public long Id { get; set; }
+
+    [Column("created_at")]
+    public System.DateTime CreatedAt { get; set; }
+
+    [Column("fecha_recurso_uti")]
+    public System.DateTime? FechaRecursoUti { get; set; }
+
+    [Column("cantidad_recursos_uti")]
+    public decimal? CantidadRecursosUti { get; set; }
+
+    [Column("precio_uni_recursos_uti")]
+    public decimal? PrecioUniRecursosUti { get; set; }
+
+    [Column("total_recursos_uti")]
+    public decimal? TotalRecursosUti { get; set; }
+
+    [Column("id_recurso")]
+    public long? IdRecurso { get; set; }
+
+    [Column("id_sub_etapa")]
+    public long? IdSubEtapa { get; set; }
+
+    [Column("id_uni_medida")]
+    public long? IdUniMedida { get; set; }
+}

--- a/Services/IDataService.cs
+++ b/Services/IDataService.cs
@@ -48,6 +48,10 @@ namespace DelCorp.Services
         Task<RecursoUti> SaveRecursoUtiAsync(RecursoUti recursoUti);
         Task DeleteRecursoUtiAsync(long recursoUtiId);
 
+        // RegistroRecursoUti
+        Task<IEnumerable<RegistroRecursoUti>> GetRegistroRecursosUtiBySubEtapaIdAsync(long subEtapaId);
+        Task<RegistroRecursoUti> SaveRegistroRecursoUtiAsync(RegistroRecursoUti registro);
+
         // Actividades categoría
         Task<IEnumerable<CategoriaActividad>> GetCategoriasActividadAsync();
         Task SaveCategoriaActividadAsync(CategoriaActividad categoriaActividad); // Principalmente para admin/sincronización

--- a/Services/LocalDatabaseService.cs
+++ b/Services/LocalDatabaseService.cs
@@ -22,6 +22,7 @@ public class LocalDatabaseService : IDisposable
         _database.CreateTableAsync<LocalUniMedRe>().Wait();
         _database.CreateTableAsync<LocalRecurso>().Wait();
         _database.CreateTableAsync<LocalRecursoUti>().Wait();
+        _database.CreateTableAsync<LocalRegistroRecursoUti>().Wait();
         _database.CreateTableAsync<LocalCategoriaActividad>().Wait();
         _database.CreateTableAsync<LocalActividad>().Wait();
     }
@@ -340,6 +341,22 @@ public class LocalDatabaseService : IDisposable
 
     public async Task<List<LocalRecursoUti>> GetUnsyncedRecursosUtiAsync() =>
         await _database.Table<LocalRecursoUti>().Where(r => !r.IsSynced).ToListAsync();
+
+    // RegistroRecursoUti
+    public async Task<List<LocalRegistroRecursoUti>> GetRegistroRecursosUtiBySubEtapaIdAsync(long subEtapaId) =>
+        await _database.Table<LocalRegistroRecursoUti>().Where(r => r.IdSubEtapa == subEtapaId).ToListAsync();
+
+    public async Task SaveRegistroRecursoUtiAsync(LocalRegistroRecursoUti item)
+    {
+        if (item.LocalId != 0)
+        {
+            await _database.UpdateAsync(item);
+        }
+        else
+        {
+            await _database.InsertAsync(item);
+        }
+    }
 
     // Para LocalCategoriaActividad
     public async Task<List<LocalCategoriaActividad>> GetCategoriasActividadAsync() =>

--- a/Services/Mapping/RecursosMapper.cs
+++ b/Services/Mapping/RecursosMapper.cs
@@ -39,5 +39,62 @@ namespace DelCorp.Services.Mapping
         public static LocalRecursoUti ToLocal(this RecursoUti dto, bool isSynced = true) => dto == null ? null : new LocalRecursoUti { ServerId = dto.Id, CreatedAt = dto.CreatedAt, CantidadRecursosUti = dto.CantidadRecursosUti, PrecioUniRecursosUti = dto.PrecioUniRecursosUti, TotalRecursosUti = dto.TotalRecursosUti, IdSubEtapa = dto.IdSubEtapa, IdRecurso = dto.IdRecurso, IdUniMedRe = dto.IdUniMedRe, IsSynced = isSynced };
         public static List<RecursoUti> ToDtoList(this IEnumerable<SupabaseRecursoUti> supabaseList) => supabaseList.Select(s => s.ToDto()).ToList();
         public static List<RecursoUti> ToDtoList(this IEnumerable<LocalRecursoUti> localList) => localList.Select(l => l.ToDto()).ToList();
+
+        // RegistroRecursoUti Mappers
+        public static RegistroRecursoUti ToDto(this SupabaseRegistroRecursoUti supabase) => supabase == null ? null : new RegistroRecursoUti
+        {
+            Id = supabase.Id,
+            CreatedAt = supabase.CreatedAt,
+            FechaRecursoUti = supabase.FechaRecursoUti,
+            CantidadRecursosUti = supabase.CantidadRecursosUti,
+            PrecioUniRecursosUti = supabase.PrecioUniRecursosUti,
+            TotalRecursosUti = supabase.TotalRecursosUti,
+            IdRecurso = supabase.IdRecurso,
+            IdSubEtapa = supabase.IdSubEtapa,
+            IdUniMedida = supabase.IdUniMedida
+        };
+
+        public static RegistroRecursoUti ToDto(this LocalRegistroRecursoUti local) => local == null ? null : new RegistroRecursoUti
+        {
+            Id = local.ServerId ?? local.LocalId,
+            CreatedAt = local.CreatedAt,
+            FechaRecursoUti = local.FechaRecursoUti,
+            CantidadRecursosUti = local.CantidadRecursosUti,
+            PrecioUniRecursosUti = local.PrecioUniRecursosUti,
+            TotalRecursosUti = local.TotalRecursosUti,
+            IdRecurso = local.IdRecurso,
+            IdSubEtapa = local.IdSubEtapa,
+            IdUniMedida = local.IdUniMedida
+        };
+
+        public static SupabaseRegistroRecursoUti ToSupabase(this RegistroRecursoUti dto) => dto == null ? null : new SupabaseRegistroRecursoUti
+        {
+            Id = dto.Id,
+            CreatedAt = dto.CreatedAt,
+            FechaRecursoUti = dto.FechaRecursoUti,
+            CantidadRecursosUti = dto.CantidadRecursosUti,
+            PrecioUniRecursosUti = dto.PrecioUniRecursosUti,
+            TotalRecursosUti = dto.TotalRecursosUti,
+            IdRecurso = dto.IdRecurso,
+            IdSubEtapa = dto.IdSubEtapa,
+            IdUniMedida = dto.IdUniMedida
+        };
+
+        public static LocalRegistroRecursoUti ToLocal(this RegistroRecursoUti dto, bool isSynced = true) => dto == null ? null : new LocalRegistroRecursoUti
+        {
+            ServerId = dto.Id,
+            CreatedAt = dto.CreatedAt,
+            FechaRecursoUti = dto.FechaRecursoUti,
+            CantidadRecursosUti = dto.CantidadRecursosUti,
+            PrecioUniRecursosUti = dto.PrecioUniRecursosUti,
+            TotalRecursosUti = dto.TotalRecursosUti,
+            IdRecurso = dto.IdRecurso,
+            IdSubEtapa = dto.IdSubEtapa,
+            IdUniMedida = dto.IdUniMedida,
+            IsSynced = isSynced
+        };
+
+        public static List<RegistroRecursoUti> ToDtoList(this IEnumerable<SupabaseRegistroRecursoUti> supabaseList) => supabaseList.Select(s => s.ToDto()).ToList();
+        public static List<RegistroRecursoUti> ToDtoList(this IEnumerable<LocalRegistroRecursoUti> localList) => localList.Select(l => l.ToDto()).ToList();
     }
 }

--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -1301,6 +1301,25 @@ namespace DelCorp.Services
             }
         }
 
+        // RegistroRecursoUti methods (local only)
+        public async Task<IEnumerable<RegistroRecursoUti>> GetRegistroRecursosUtiBySubEtapaIdAsync(long subEtapaId)
+        {
+            var localItems = await _localDatabase.GetRegistroRecursosUtiBySubEtapaIdAsync(subEtapaId);
+            return localItems.Select(l => RecursosMapper.ToDto(l)).OrderByDescending(r => r.FechaRecursoUti);
+        }
+
+        public async Task<RegistroRecursoUti> SaveRegistroRecursoUtiAsync(RegistroRecursoUti registro)
+        {
+            registro.CreatedAt = DateTime.UtcNow;
+            if (registro.CantidadRecursosUti.HasValue && registro.PrecioUniRecursosUti.HasValue)
+                registro.TotalRecursosUti = registro.CantidadRecursosUti.Value * registro.PrecioUniRecursosUti.Value;
+
+            var local = RecursosMapper.ToLocal(registro, isSynced: false);
+            await _localDatabase.SaveRegistroRecursoUtiAsync(local);
+            registro.Id = local.LocalId;
+            return registro;
+        }
+
         public async Task SyncRecursosUtiAsync() //
         {
             if (_connectivity.NetworkAccess != NetworkAccess.Internet) return; //

--- a/ViewModels/RegistrarRecursoUtiViewModel.cs
+++ b/ViewModels/RegistrarRecursoUtiViewModel.cs
@@ -49,6 +49,9 @@ namespace DelCorp.ViewModels
         private decimal? _totalCalculado;
 
         [ObservableProperty]
+        private System.DateTime? _fechaRecursoUti = System.DateTime.Today;
+
+        [ObservableProperty]
         private bool _isBusy;
 
         public bool IsNotBusy => !IsBusy;
@@ -192,7 +195,19 @@ namespace DelCorp.ViewModels
                     CreatedAt = System.DateTime.UtcNow // Service should handle this ideally
                 };
 
+                var registro = new RegistroRecursoUti
+                {
+                    Id = 0,
+                    IdSubEtapa = IdSubEtapa,
+                    IdRecurso = SelectedRecurso.Id,
+                    IdUniMedida = SelectedUniMedRe.Id,
+                    CantidadRecursosUti = Cantidad,
+                    PrecioUniRecursosUti = PrecioUnitario,
+                    FechaRecursoUti = FechaRecursoUti,
+                };
+
                 var savedItem = await _dataService.SaveRecursoUtiAsync(newRecursoUti);
+                await _dataService.SaveRegistroRecursoUtiAsync(registro);
 
                 // To show details like name, re-fetch or update the savedItem with navigation properties
                 savedItem.Recurso = SelectedRecurso;
@@ -207,6 +222,7 @@ namespace DelCorp.ViewModels
                 Cantidad = null;
                 PrecioUnitario = null;
                 TotalCalculado = null;
+                FechaRecursoUti = System.DateTime.Today;
                 OnPropertyChanged(nameof(SelectedRecurso)); // Notify picker to reset
                 OnPropertyChanged(nameof(SelectedUniMedRe));
             }

--- a/Views/RegistrarRecursoUtiPage.xaml
+++ b/Views/RegistrarRecursoUtiPage.xaml
@@ -23,6 +23,8 @@
                     ItemDisplayBinding="{Binding NombreUniMedRe}"
                     SelectedItem="{Binding SelectedUniMedRe}"/>
 
+            <DatePicker Date="{Binding FechaRecursoUti}" />
+
             <Entry Placeholder="Cantidad" Keyboard="Numeric" Text="{Binding Cantidad}"/>
             <Entry Placeholder="Precio Unitario" Keyboard="Numeric" Text="{Binding PrecioUnitario}"/>
             <Label Text="{Binding TotalCalculado, StringFormat='Total: C${0:N2}'}"/>


### PR DESCRIPTION
## Summary
- add models for `RegistroRecursoUti`
- store new records in local DB
- expose new methods on `IDataService`
- implement local handling in `OfflineFirstDataService`
- map between DTO/Local/Supabase models
- extend resource registration view and viewmodel with date field

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845dbe952a8832bad028f7a005f2d33