### PR TITLE
Optimize local updates for Etapa data

### DIFF
--- a/Services/LocalDatabaseService.cs
+++ b/Services/LocalDatabaseService.cs
@@ -154,6 +154,25 @@ public class LocalDatabaseService : IDisposable
 
     public async Task SaveEtapaAsync(LocalEtapa etapa)
     {
+        // Try to update existing records when possible to avoid duplicates
+        if (etapa.Id != 0)
+        {
+            await _database.UpdateAsync(etapa);
+            return;
+        }
+
+        if (etapa.ServerId.HasValue)
+        {
+            var existing = await _database.Table<LocalEtapa>()
+                .FirstOrDefaultAsync(e => e.ServerId == etapa.ServerId.Value);
+            if (existing != null)
+            {
+                etapa.Id = existing.Id;
+                await _database.UpdateAsync(etapa);
+                return;
+            }
+        }
+
         await _database.InsertAsync(etapa);
     }
 
@@ -201,6 +220,24 @@ public class LocalDatabaseService : IDisposable
     }
     public async Task SaveSubEtapaAsync(LocalSubEtapa subEtapa)
     {
+        if (subEtapa.Id != 0)
+        {
+            await _database.UpdateAsync(subEtapa);
+            return;
+        }
+
+        if (subEtapa.ServerId.HasValue)
+        {
+            var existing = await _database.Table<LocalSubEtapa>()
+                .FirstOrDefaultAsync(x => x.ServerId == subEtapa.ServerId.Value);
+            if (existing != null)
+            {
+                subEtapa.Id = existing.Id;
+                await _database.UpdateAsync(subEtapa);
+                return;
+            }
+        }
+
         await _database.InsertAsync(subEtapa);
     }
 

--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -398,28 +398,25 @@ namespace DelCorp.Services
 
                         if (remoteEtapas.Any())
                         {
-                            await _localDatabase.DeleteEtapasByPresupuestoIdAsync(presupuestoId);
-                            System.Diagnostics.Debug.WriteLine("[GetEtapasByPresupuestoId] Etapas locales eliminadas para sincronización.");
-
                             foreach (var remoteEtapa in remoteEtapas)
                             {
                                 var dtoRemote = remoteEtapa.ToDto();
                                 var localEtapa = dtoRemote.ToLocal();
 
-                                // Asigna siempre el IdPresupuesto local recibido
                                 localEtapa.IdPresupuesto = presupuestoId;
-                                System.Diagnostics.Debug.WriteLine($"[GetEtapasByPresupuestoId] Asignando SIEMPRE IdPresupuesto local {presupuestoId} a etapa remota {localEtapa.Id}");
-
                                 localEtapa.IsSynced = true;
+
+                                var existingLocal = await _localDatabase.GetEtapaByServerIdAsync(remoteEtapa.Id);
+                                if (existingLocal != null)
+                                {
+                                    localEtapa.Id = existingLocal.Id;
+                                }
+
                                 await _localDatabase.SaveEtapaAsync(localEtapa);
-                                System.Diagnostics.Debug.WriteLine($"[GetEtapasByPresupuestoId] Etapa remota guardada localmente: Id={localEtapa.Id}, Actividad={localEtapa.IdActividadEtapa}, PresupuestoId={localEtapa.IdPresupuesto},");
                             }
 
-
                             // Recargar etapas locales
-                            System.Diagnostics.Debug.WriteLine($"Retornar etapas localmente del presupuesto ID: {presupuestoId}");
                             localEtapas = await _localDatabase.GetEtapasByPresupuestoIdAsync(presupuestoId);
-                            System.Diagnostics.Debug.WriteLine($"[GetEtapasByPresupuestoId] Etapas locales recargadas: {localEtapas.Count}");
                             dtoEtapas = localEtapas.ToDtoList();
                         }
                         else
@@ -850,9 +847,6 @@ namespace DelCorp.Services
 
                         if (remoteSubEtapas.Any())
                         {
-                            System.Diagnostics.Debug.WriteLine("[GetSubEtapasByEtapaId] Eliminando subetapas locales previas para sincronizar.");
-                            await _localDatabase.DeleteSubEtapasByEtapaIdAsync(etapaId);
-
                             foreach (var remoteSubEtapa in remoteSubEtapas)
                             {
                                 var dtoRemote = remoteSubEtapa.ToDto();
@@ -861,15 +855,17 @@ namespace DelCorp.Services
                                 localSubEtapa.IdEtapa = etapaId;
                                 localSubEtapa.IsSynced = true;
 
-                                System.Diagnostics.Debug.WriteLine($"[GetSubEtapasByEtapaId] Guardando subetapa remota localmente: Id={localSubEtapa.Id}, Actividad={localSubEtapa.ActividadSubEtapaId}, EtapaId={localSubEtapa.IdEtapa}");
+                                var existingLocal = await _localDatabase.GetLocalSubEtapaByIdAsync(remoteSubEtapa.Id);
+                                if (existingLocal != null)
+                                {
+                                    localSubEtapa.Id = existingLocal.Id;
+                                }
 
                                 await _localDatabase.SaveSubEtapaAsync(localSubEtapa);
                             }
 
                             // Recargar subetapas locales
-                            System.Diagnostics.Debug.WriteLine($"[GetSubEtapasByEtapaId] Recargando subetapas locales tras sincronización para EtapaId: {etapaId}");
                             localSubEtapas = await _localDatabase.GetSubEtapasByEtapaIdAsync(etapaId);
-                            System.Diagnostics.Debug.WriteLine($"[GetSubEtapasByEtapaId] Subetapas locales recargadas: {localSubEtapas.Count}");
                             dtoEtapas = localSubEtapas.Select(e => e.ToDto()).ToList();
                         }
                         else


### PR DESCRIPTION
## Summary
- keep local IDs when syncing etapas/subetapas
- update or insert individual items instead of clearing the table

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e20a0fac832bb750d9ee9783975b