### PR TITLE
Implement inline activity creation for etapas

### DIFF
--- a/Converters/CountToBoolConverter.cs
+++ b/Converters/CountToBoolConverter.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace DelCorp.Converters
+{
+    public class CountToBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is int count)
+            {
+                return count > 0;
+            }
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Resources/Styles/Converters.xaml
+++ b/Resources/Styles/Converters.xaml
@@ -5,5 +5,6 @@
 
     <converters:StringToBoolConverter x:Key="StringToBoolConverter"/>
     <converters:InverseBoolConverter x:Key="InverseBoolConverter"/>
+    <converters:CountToBoolConverter x:Key="CountToBoolConverter"/>
 
 </ResourceDictionary>

--- a/ViewModels/RegistrarEtapaViewModel.cs
+++ b/ViewModels/RegistrarEtapaViewModel.cs
@@ -57,6 +57,12 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
     private string _searchTextActividad;
 
     [ObservableProperty]
+    private bool _showNewActividadFields;
+
+    [ObservableProperty]
+    private bool _isActividadFromList;
+
+    [ObservableProperty]
     private bool _hasPendingOrderChanges = false; // Nueva propiedad
 
     public bool IsNotBusy => !IsBusy;
@@ -77,8 +83,49 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
     // ... (CargarUniMedReAsync, CargarCategoriasActividadAsync, CargarActividadesAsync, etc. sin cambios) ...
     async partial void OnSearchTextActividadChanged(string oldValue, string newValue)
     {
-        Debug.WriteLine($"[RegistrarEtapaVM] SearchTextActividad cambiado a: {newValue}");
+        // Si el cambio proviene de la selección en la lista, no recargar
+        if (IsActividadFromList)
+        {
+            IsActividadFromList = false;
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(newValue))
+        {
+            ActividadesDisponibles.Clear();
+            ShowNewActividadFields = false;
+            SelectedActividad = null;
+            return;
+        }
+
         await CargarActividadesAsync(null, newValue);
+
+        var exactMatch = ActividadesDisponibles
+            .FirstOrDefault(a => a.NombreActividad.Equals(newValue, StringComparison.OrdinalIgnoreCase));
+
+        if (exactMatch != null && exactMatch.IdActividad != -1)
+        {
+            ShowNewActividadFields = false;
+            SelectedActividad = exactMatch;
+        }
+        else
+        {
+            ShowNewActividadFields = true;
+            SelectedActividad = null;
+        }
+    }
+
+    [RelayCommand]
+    private void SelectActividad(Actividad actividad)
+    {
+        if (actividad == null) return;
+
+        IsActividadFromList = true;
+        SearchTextActividad = actividad.NombreActividad;
+        SelectedActividad = actividad;
+
+        ShowNewActividadFields = false;
+        ActividadesDisponibles.Clear();
     }
 
     public async Task ActualizarEtapaConSubetapas(long idEtapa)
@@ -354,43 +401,30 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
     }
 
     [RelayCommand]
-    public async Task GuardarEtapaAsync() //Guardar nueva etapa
+    public async Task GuardarEtapaAsync()
     {
-        // ... (Validaciones iniciales y lógica para nueva actividad sin cambios)...
         SetIsBusy(true);
         long? idActividadParaGuardar = null;
 
-        if (SelectedActividad == null)
+        if (string.IsNullOrWhiteSpace(SearchTextActividad))
         {
-            await Shell.Current.DisplayAlert("Validación", "Debe seleccionar una actividad para la etapa.", "OK");
+            await Shell.Current.DisplayAlert("Validación", "Debe escribir o seleccionar una actividad para la etapa.", "OK");
             SetIsBusy(false);
             return;
         }
 
-        if (SelectedActividad.IdActividad == -1) // User wants to register a new activity
+        if (ShowNewActividadFields)
         {
-            if (string.IsNullOrWhiteSpace(NombreNuevaActividad))
+            if (SelectedCategoriaActividad == null || SelectedUniMedRe == null)
             {
-                await Shell.Current.DisplayAlert("Validación", "El nombre de la nueva actividad es obligatorio.", "OK");
-                SetIsBusy(false);
-                return;
-            }
-            if (SelectedCategoriaActividad == null)
-            {
-                await Shell.Current.DisplayAlert("Validación", "Debe seleccionar una categoría para la nueva actividad.", "OK");
-                SetIsBusy(false);
-                return;
-            }
-            if (SelectedUniMedRe == null)
-            {
-                await Shell.Current.DisplayAlert("Validación", "Debe seleccionar una unidad de medida para la nueva actividad.", "OK");
+                await Shell.Current.DisplayAlert("Validación", "Para registrar una nueva actividad, debe seleccionar su categoría y unidad de medida.", "OK");
                 SetIsBusy(false);
                 return;
             }
 
             var nuevaActividadDto = new Actividad
             {
-                NombreActividad = NombreNuevaActividad,
+                NombreActividad = SearchTextActividad,
                 CategoriaActividadId = SelectedCategoriaActividad.IdCategoriaActividad,
                 UnidadMedidaId = SelectedUniMedRe.Id,
                 CreatedAt = DateTime.UtcNow
@@ -399,19 +433,24 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
             var actividadGuardada = await _dataService.SaveActividadAsync(nuevaActividadDto);
             if (actividadGuardada == null || actividadGuardada.IdActividad == 0)
             {
-                await Shell.Current.DisplayAlert("Error", "No se pudo guardar la nueva actividad. Verifique los datos o la conexión.", "OK");
+                await Shell.Current.DisplayAlert("Error", "No se pudo guardar la nueva actividad.", "OK");
                 SetIsBusy(false);
                 return;
             }
             idActividadParaGuardar = actividadGuardada.IdActividad;
-            await CargarActividadesAsync(null, SearchTextActividad);
         }
         else
         {
+            if (SelectedActividad == null)
+            {
+                await Shell.Current.DisplayAlert("Error", "La actividad seleccionada no es válida. Por favor, elíjala de la lista.", "OK");
+                SetIsBusy(false);
+                return;
+            }
             idActividadParaGuardar = SelectedActividad.IdActividad;
         }
 
-        if (!idActividadParaGuardar.HasValue || idActividadParaGuardar.Value == 0)
+        if (!idActividadParaGuardar.HasValue)
         {
             await Shell.Current.DisplayAlert("Error", "No se pudo determinar la actividad para la etapa.", "OK");
             SetIsBusy(false);
@@ -437,13 +476,14 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
             var etapaGuardada = await _dataService.SaveEtapa(etapa);
             if (etapaGuardada != null)
             {
-                SelectedActividad = null;
-                CantidadEtapa = null;
-                NombreNuevaActividad = string.Empty;
                 SearchTextActividad = string.Empty;
-                MostrarCampoNuevaActividad = false;
+                ShowNewActividadFields = false;
+                SelectedActividad = null;
+                SelectedCategoriaActividad = null;
+                SelectedUniMedRe = null;
+                CantidadEtapa = null;
 
-                await CargarEtapasAsync(); // Esto recargará y ordenará por NumeroEtapa
+                await CargarEtapasAsync(); // Recarga la lista de etapas
                 await Shell.Current.DisplayAlert("Éxito", $"Etapa guardada con número {etapaGuardada.NumeroEtapa}.", "OK");
             }
             else

--- a/Views/RegistrarEtapaPage.xaml
+++ b/Views/RegistrarEtapaPage.xaml
@@ -9,40 +9,60 @@
     <ContentPage.Resources>
         <ResourceDictionary>
             <converters:InverseBoolConverter x:Key="InverseBoolConverter" />
+            <converters:CountToBoolConverter x:Key="CountToBoolConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ScrollView>
         <VerticalStackLayout Spacing="10" Padding="20">
 
-            <Label Text="Registrar Nueva Etapa" FontAttributes="Bold" FontSize="Medium"/>
+            <Label Text="Nombre de la Etapa/Actividad" FontAttributes="Bold"/>
+            <Frame Padding="0" CornerRadius="8" BorderColor="LightGray">
+                <Entry Placeholder="Escriba para buscar o crear..."
+                       Text="{Binding SearchTextActividad, Mode=TwoWay}"
+                       ClearButtonVisibility="WhileEditing"
+                       VerticalOptions="Center"/>
+            </Frame>
 
-            <Picker Title="Seleccionar Actividad"
-                    ItemsSource="{Binding ActividadesDisponibles}"
-                    ItemDisplayBinding="{Binding NombreActividad}"
-                    SelectedItem="{Binding SelectedActividad}" />
+            <CollectionView ItemsSource="{Binding ActividadesDisponibles}"
+                            SelectionMode="None"
+                            MaximumHeightRequest="150"
+                            IsVisible="{Binding ActividadesDisponibles.Count, Converter={StaticResource CountToBoolConverter}}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:Actividad">
+                        <StackLayout Padding="10" Spacing="5">
+                            <Label Text="{Binding NombreActividad}" FontSize="16"/>
+                            <StackLayout.GestureRecognizers>
+                                <TapGestureRecognizer 
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:RegistrarEtapaViewModel}}, Path=SelectActividadCommand}"
+                                    CommandParameter="{Binding .}"/>
+                            </StackLayout.GestureRecognizers>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
 
-            <Entry Placeholder="Nombre de Nueva Actividad"
-                   Text="{Binding NombreNuevaActividad}"
-                   IsVisible="{Binding MostrarCampoNuevaActividad}" />
+            <VerticalStackLayout IsVisible="{Binding ShowNewActividadFields}" Spacing="10">
+                <Label Text="Registrar Nueva Actividad" FontAttributes="Bold" TextColor="#512BD4"/>
+                <Picker Title="Seleccione una Categoría"
+                        ItemsSource="{Binding CategoriasActividad}"
+                        ItemDisplayBinding="{Binding NombreCategoriaActividad}"
+                        SelectedItem="{Binding SelectedCategoriaActividad}"/>
+                <Picker Title="Seleccione Unidad de Medida"
+                        ItemsSource="{Binding DisponibleUniMedRe}"
+                        ItemDisplayBinding="{Binding NombreUniMedRe}"
+                        SelectedItem="{Binding SelectedUniMedRe}"/>
+            </VerticalStackLayout>
 
-            <Picker Title="Categoría para Nueva Actividad"
-                    ItemsSource="{Binding CategoriasActividad}"
-                    ItemDisplayBinding="{Binding NombreCategoriaActividad}"
-                    SelectedItem="{Binding SelectedCategoriaActividad}"
-                    IsVisible="{Binding MostrarCampoNuevaActividad}"
-                    IsEnabled="{Binding PickersForNewActivityEnabled}" />
+            <Label Text="Cantidad" FontAttributes="Bold" Margin="0,15,0,0"/>
+            <Frame Padding="0" CornerRadius="8" BorderColor="LightGray">
+                 <Entry Placeholder="Ej: 100" Keyboard="Numeric" Text="{Binding CantidadEtapa}" />
+            </Frame>
 
-            <Picker Title="Unidad de Medida para Nueva Actividad"
-                    ItemsSource="{Binding DisponibleUniMedRe}"
-                    ItemDisplayBinding="{Binding NombreUniMedRe}"
-                    SelectedItem="{Binding SelectedUniMedRe}"
-                    IsVisible="{Binding MostrarCampoNuevaActividad}"
-                    IsEnabled="{Binding PickersForNewActivityEnabled}" />
-
-            <Button Text="Guardar Etapa"
-                    Command="{Binding GuardarEtapaCommand}"
-                    IsEnabled="{Binding IsNotBusy}" />
+            <Button Text="Guardar Etapa" 
+                    Command="{Binding GuardarEtapaCommand}" 
+                    IsEnabled="{Binding IsNotBusy}"
+                    Margin="0,20,0,0"/>
 
             <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
 


### PR DESCRIPTION
## Summary
- add `CountToBoolConverter` helper
- support inline activity search and creation in `RegistrarEtapaViewModel`
- update etapa registration page UI for new workflow
- register new converter in resource dictionary

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fe15828c832b8bdd7526ddc571db