### PR TITLE
Update budget totals and services

### DIFF
--- a/Services/IDataService.cs
+++ b/Services/IDataService.cs
@@ -18,6 +18,7 @@ namespace DelCorp.Services
         Task<IEnumerable<Presupuesto>> GetPresupuestosByProjectId(int projectId);
         Task<IEnumerable<Presupuesto>> GetAllPresupuestos();
         Task<bool> DeletePresupuesto(long presupuestoId);
+        Task<Presupuesto> GetPresupuestoByIdAsync(long presupuestoId);
 
 
         //Etapas de presupuestos

--- a/Services/LocalDatabaseService.cs
+++ b/Services/LocalDatabaseService.cs
@@ -118,6 +118,12 @@ public class LocalDatabaseService : IDisposable
             .FirstOrDefaultAsync(p => p.ServerId == serverId);
     }
 
+    public async Task<LocalPresupuesto> GetPresupuestoByIdAsync(long id)
+    {
+        return await _database.Table<LocalPresupuesto>()
+            .FirstOrDefaultAsync(p => p.Id == (int)id || p.ServerId == id);
+    }
+
     public async Task SavePresupuestoAsync(LocalPresupuesto presupuesto)
     {
         // Verifica si el presupuesto ya tiene un ID local.

--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -581,49 +581,50 @@ namespace DelCorp.Services
         {
             try
             {
-                // Si hay conexión, primero guarda en Supabase para obtener el ID
+                if (presupuesto.Id == 0)
+                {
+                    presupuesto.CreatedAt = DateTime.Now;
+                }
+
+                var localPresupuesto = presupuesto.ToLocal();
+                if (presupuesto.Id != 0 && localPresupuesto.ServerId == null)
+                {
+                    localPresupuesto.ServerId = presupuesto.Id;
+                }
+
+                await _localDatabase.SavePresupuestoAsync(localPresupuesto);
+
                 if (_connectivity.NetworkAccess == NetworkAccess.Internet)
                 {
                     try
                     {
-                        presupuesto.Id = GenerarIdAleatorio();
-                        presupuesto.CreatedAt = DateTime.Now;
-
-                        // Convertir a modelo Supabase
                         var supabasePresupuesto = presupuesto.ToSupabase();
-
-                        // Enviar al servidor
                         var response = await _supabaseClient.From<SupabasePresupuesto>().Upsert(supabasePresupuesto);
                         var syncedPresupuesto = response.Models.FirstOrDefault();
 
                         if (syncedPresupuesto != null)
                         {
-                            // Actualizar el modelo con el ID y fecha generados por Supabase
-                            presupuesto.Id = syncedPresupuesto.Id;
-                            presupuesto.CreatedAt = syncedPresupuesto.CreatedAt;
-
-                            // Guardar localmente con el ID de Supabase
-                            var localPresupuesto = presupuesto.ToLocal();
                             localPresupuesto.ServerId = syncedPresupuesto.Id;
+                            localPresupuesto.CreatedAt = syncedPresupuesto.CreatedAt;
                             localPresupuesto.IsSynced = true;
                             await _localDatabase.SavePresupuestoAsync(localPresupuesto);
-
                             return syncedPresupuesto.ToDto();
                         }
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError($"Error al sincronizar presupuesto: {ex.Message}");
-                        System.Diagnostics.Debug.WriteLine($"Error al sincronizar presupuesto: {ex.Message}");
+                        localPresupuesto.IsSynced = false;
+                        await _localDatabase.SavePresupuestoAsync(localPresupuesto);
                     }
                 }
+                else
+                {
+                    localPresupuesto.IsSynced = false;
+                    await _localDatabase.SavePresupuestoAsync(localPresupuesto);
+                }
 
-                // Si no hay conexión, guardar localmente sin ID de servidor
-                var localPresupuestoOffline = presupuesto.ToLocal();
-                localPresupuestoOffline.IsSynced = false;
-                await _localDatabase.SavePresupuestoAsync(localPresupuestoOffline);
-
-                return localPresupuestoOffline.ToDto();
+                return localPresupuesto.ToDto();
             }
             catch (Exception ex)
             {
@@ -767,6 +768,58 @@ namespace DelCorp.Services
                 _logger.LogError($"Error al eliminar presupuesto: {ex.Message}");
                 System.Diagnostics.Debug.WriteLine($"Error al eliminar presupuesto: {ex.Message}");
                 return false;
+            }
+        }
+
+        public async Task<Presupuesto> GetPresupuestoByIdAsync(long presupuestoId)
+        {
+            try
+            {
+                var localPresupuesto = await _localDatabase.GetPresupuestoByServerIdAsync(presupuestoId);
+                if (localPresupuesto == null)
+                {
+                    var allLocal = await _localDatabase.GetAllPresupuestosAsync();
+                    localPresupuesto = allLocal.FirstOrDefault(p => p.Id == presupuestoId);
+                }
+
+                if (_connectivity.NetworkAccess == NetworkAccess.Internet)
+                {
+                    try
+                    {
+                        var response = await _supabaseClient
+                            .From<SupabasePresupuesto>()
+                            .Filter("id", Postgrest.Constants.Operator.Equals, presupuestoId.ToString())
+                            .Single();
+
+                        if (response != null)
+                        {
+                            var remoteDto = response.ToDto();
+                            if (localPresupuesto == null || (localPresupuesto.ServerId == remoteDto.Id && localPresupuesto.IsSynced))
+                            {
+                                var updatedLocal = remoteDto.ToLocal();
+                                if (localPresupuesto != null) updatedLocal.Id = localPresupuesto.Id;
+                                updatedLocal.IsSynced = true;
+                                await _localDatabase.SavePresupuestoAsync(updatedLocal);
+                            }
+                            return remoteDto;
+                        }
+                    }
+                    catch (Postgrest.Exceptions.PostgrestException pgex) when (pgex.Message.Contains("PGRST116"))
+                    {
+                        _logger.LogWarning($"Presupuesto with ID {presupuestoId} not found on server. PGRST116.");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, $"Error fetching Presupuesto {presupuestoId} from Supabase. Falling back to local if available.");
+                    }
+                }
+
+                return localPresupuesto?.ToDto();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Error in GetPresupuestoByIdAsync for {presupuestoId}.");
+                return null;
             }
         }
 

--- a/ViewModels/RegistrarEtapaViewModel.cs
+++ b/ViewModels/RegistrarEtapaViewModel.cs
@@ -15,6 +15,9 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
     private readonly IDataService _dataService;
 
     [ObservableProperty]
+    private Presupuesto _currentPresupuesto;
+
+    [ObservableProperty]
     private decimal? _cantidadEtapa;
 
     [ObservableProperty]
@@ -94,6 +97,7 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
     {
         IdPresupuesto = presupuestoId;
         Debug.WriteLine($"[RegistrarEtapaVM] Inicializando con IdPresupuesto: {IdPresupuesto}");
+        CurrentPresupuesto = await _dataService.GetPresupuestoByIdAsync(presupuestoId);
         SetIsBusy(true);
         try
         {
@@ -214,6 +218,7 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
                 Etapas.Add(etapa);
             }
             HasPendingOrderChanges = false; // Resetea la bandera después de cargar desde la fuente
+            await UpdatePresupuestoTotalAsync();
         }
         catch (Exception ex)
         {
@@ -351,6 +356,20 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
                 .Sum(s => s.CantidadSubEtapa.Value);
         }
         etapa.CantidadEtapa = cantidadCalculadaEtapa;
+    }
+
+    private async Task UpdatePresupuestoTotalAsync()
+    {
+        if (CurrentPresupuesto == null) return;
+
+        decimal newTotal = Etapas.Sum(e => e.MontoTotalEtapa ?? 0M);
+
+        if (CurrentPresupuesto.TotalPresupuesto != newTotal)
+        {
+            CurrentPresupuesto.TotalPresupuesto = newTotal;
+            await _dataService.SavePresupuesto(CurrentPresupuesto);
+            OnPropertyChanged(nameof(CurrentPresupuesto));
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- load current budget in `RegistrarEtapaViewModel`
- keep budget total in sync when stages are modified
- expose `GetPresupuestoByIdAsync` and update data services
- allow retrieving budget by local or server id
- improve saving budgets for update scenarios

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d87b1728832b9f185443302c1a54