### PR TITLE
Implement recurso ejecutado registration

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -14,6 +14,7 @@ namespace DelCorp
             RegisterForRoute<RegistrarEtapaPage>();
             RegisterForRoute<RegistrarSubEtapaPage>();
             RegisterForRoute<RegistrarRecursoUtiPage>();
+            RegisterForRoute<RegistrarRecursoEjecutadoPage>();
         }
 
         protected void RegisterForRoute<T>()

--- a/DelCorp.csproj
+++ b/DelCorp.csproj
@@ -102,12 +102,15 @@
 	  <MauiXaml Update="Views\RegistrarPresupuestoPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\RegistrarRecursoUtiPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\RegistrarSubEtapaPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+          <MauiXaml Update="Views\RegistrarRecursoUtiPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\RegistrarRecursoEjecutadoPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\RegistrarSubEtapaPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
 	  <MauiXaml Update="Views\UserProfilePage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -52,6 +52,7 @@ namespace DelCorp
             builder.Services.AddTransient<RegistrarEtapaViewModel>();
             builder.Services.AddTransient<RegistrarSubEtapaViewModel>();
             builder.Services.AddTransient<RegistrarRecursoUtiViewModel>();
+            builder.Services.AddTransient<RegistrarRecursoEjecutadoViewModel>();
 
             // Views
             builder.Services.AddSingleton<ProjectPage>();
@@ -65,6 +66,7 @@ namespace DelCorp
             builder.Services.AddTransient<RegistrarEtapaPage>();
             builder.Services.AddTransient<RegistrarSubEtapaPage>();
             builder.Services.AddTransient<RegistrarRecursoUtiPage>();
+            builder.Services.AddTransient<RegistrarRecursoEjecutadoPage>();
 
             // Servicios
             builder.Services.AddSingleton<IDataService, OfflineFirstDataService>();

--- a/Models/Local/LocalRegistroRecursoUti.cs
+++ b/Models/Local/LocalRegistroRecursoUti.cs
@@ -1,0 +1,22 @@
+using SQLite;
+using System;
+
+namespace DelCorp.Models.Local
+{
+    [Table("LocalRegistroRecursoUti")]
+    public class LocalRegistroRecursoUti
+    {
+        [PrimaryKey, AutoIncrement]
+        public long LocalId { get; set; }
+        public long? ServerId { get; set; }
+        public bool IsSynced { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? FechaRecursoUti { get; set; }
+        public decimal? CantidadRecursosUti { get; set; }
+        public decimal? PrecioUniRecursosUti { get; set; }
+        public decimal? TotalRecursosUti { get; set; }
+        public long? IdRecurso { get; set; }
+        public long? IdSubEtapa { get; set; }
+        public long? IdUniMedida { get; set; }
+    }
+}

--- a/Models/RegistroRecursoUti.cs
+++ b/Models/RegistroRecursoUti.cs
@@ -1,0 +1,42 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+
+namespace DelCorp.Models
+{
+    public partial class RegistroRecursoUti : ObservableObject
+    {
+        [ObservableProperty]
+        private long _id;
+
+        [ObservableProperty]
+        private DateTime _createdAt;
+
+        [ObservableProperty]
+        private DateTime? _fechaRecursoUti;
+
+        [ObservableProperty]
+        private decimal? _cantidadRecursosUti;
+
+        [ObservableProperty]
+        private decimal? _precioUniRecursosUti;
+
+        [ObservableProperty]
+        private decimal? _totalRecursosUti;
+
+        [ObservableProperty]
+        private long? _idRecurso;
+
+        [ObservableProperty]
+        private long? _idSubEtapa;
+
+        [ObservableProperty]
+        private long? _idUniMedida;
+
+        // Navigation properties for display
+        [ObservableProperty]
+        private Recurso _recurso;
+
+        [ObservableProperty]
+        private UniMedRe _uniMedRe;
+    }
+}

--- a/Models/Supabase/SupabaseRegistroRecursoUti.cs
+++ b/Models/Supabase/SupabaseRegistroRecursoUti.cs
@@ -1,0 +1,37 @@
+using Postgrest.Attributes;
+using Postgrest.Models;
+using System;
+
+namespace DelCorp.Models.Supabase
+{
+    [Table("registro_recursos_uti")]
+    public class SupabaseRegistroRecursoUti : BaseModel
+    {
+        [PrimaryKey("id_registro_recurso_uti", false)]
+        public long IdRegistroRecursoUti { get; set; }
+
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [Column("fecha_recurso_uti")]
+        public DateTime? FechaRecursoUti { get; set; }
+
+        [Column("cantidad_recursos_uti")]
+        public decimal? CantidadRecursosUti { get; set; }
+
+        [Column("precio_uni_recursos_uti")]
+        public decimal? PrecioUniRecursosUti { get; set; }
+
+        [Column("total_recursos_uti")]
+        public decimal? TotalRecursosUti { get; set; }
+
+        [Column("id_recurso")]
+        public long? IdRecurso { get; set; }
+
+        [Column("id_sub_etapa")]
+        public long? IdSubEtapa { get; set; }
+
+        [Column("id_uni_medida")]
+        public long? IdUniMedida { get; set; }
+    }
+}

--- a/Services/IDataService.cs
+++ b/Services/IDataService.cs
@@ -49,6 +49,12 @@ namespace DelCorp.Services
         Task<RecursoUti> SaveRecursoUtiAsync(RecursoUti recursoUti);
         Task DeleteRecursoUtiAsync(long recursoUtiId);
 
+        // RegistroRecursoUti
+        Task<IEnumerable<RegistroRecursoUti>> GetRegistrosRecursoUtiBySubEtapaIdAsync(long subEtapaId);
+        Task<RegistroRecursoUti> SaveRegistroRecursoUtiAsync(RegistroRecursoUti registro);
+        Task DeleteRegistroRecursoUtiAsync(long registroId);
+        Task UpdateExecutionTotalsForSubEtapaAsync(long subEtapaId);
+
         // Actividades categoría
         Task<IEnumerable<CategoriaActividad>> GetCategoriasActividadAsync();
         Task SaveCategoriaActividadAsync(CategoriaActividad categoriaActividad); // Principalmente para admin/sincronización

--- a/Services/LocalDatabaseService.cs
+++ b/Services/LocalDatabaseService.cs
@@ -22,6 +22,7 @@ public class LocalDatabaseService : IDisposable
         _database.CreateTableAsync<LocalUniMedRe>().Wait();
         _database.CreateTableAsync<LocalRecurso>().Wait();
         _database.CreateTableAsync<LocalRecursoUti>().Wait();
+        _database.CreateTableAsync<LocalRegistroRecursoUti>().Wait();
         _database.CreateTableAsync<LocalCategoriaActividad>().Wait();
         _database.CreateTableAsync<LocalActividad>().Wait();
     }
@@ -393,6 +394,52 @@ public class LocalDatabaseService : IDisposable
 
     public async Task<List<LocalRecursoUti>> GetUnsyncedRecursosUtiAsync() =>
         await _database.Table<LocalRecursoUti>().Where(r => !r.IsSynced).ToListAsync();
+
+    // RegistroRecursoUti
+    public async Task<List<LocalRegistroRecursoUti>> GetRegistrosRecursoUtiBySubEtapaIdAsync(long subEtapaId) =>
+        await _database.Table<LocalRegistroRecursoUti>().Where(r => r.IdSubEtapa == subEtapaId).ToListAsync();
+
+    public async Task<LocalRegistroRecursoUti> GetLocalRegistroRecursoUtiByServerIdAsync(long serverId) =>
+        await _database.Table<LocalRegistroRecursoUti>().FirstOrDefaultAsync(r => r.ServerId == serverId);
+
+    public async Task<LocalRegistroRecursoUti> GetLocalRegistroRecursoUtiByLocalIdAsync(long localId) =>
+        await _database.Table<LocalRegistroRecursoUti>().FirstOrDefaultAsync(r => r.LocalId == localId);
+
+    public async Task SaveRegistroRecursoUtiAsync(LocalRegistroRecursoUti item)
+    {
+        if (item.LocalId != 0)
+        {
+            await _database.UpdateAsync(item);
+        }
+        else if (item.ServerId.HasValue)
+        {
+            var existingByServer = await GetLocalRegistroRecursoUtiByServerIdAsync(item.ServerId.Value);
+            if (existingByServer != null)
+            {
+                item.LocalId = existingByServer.LocalId;
+                await _database.UpdateAsync(item);
+            }
+            else
+            {
+                item.LocalId = 0;
+                await _database.InsertAsync(item);
+            }
+        }
+        else
+        {
+            item.LocalId = 0;
+            await _database.InsertAsync(item);
+        }
+    }
+
+    public async Task DeleteRegistroRecursoUtiByLocalIdAsync(long localId)
+    {
+        var item = await _database.Table<LocalRegistroRecursoUti>().FirstOrDefaultAsync(x => x.LocalId == localId);
+        if (item != null) await _database.DeleteAsync(item);
+    }
+
+    public async Task<List<LocalRegistroRecursoUti>> GetUnsyncedRegistrosRecursoUtiAsync() =>
+        await _database.Table<LocalRegistroRecursoUti>().Where(r => !r.IsSynced).ToListAsync();
 
     // Para LocalCategoriaActividad
     public async Task<List<LocalCategoriaActividad>> GetCategoriasActividadAsync() =>

--- a/Services/Mapping/RegistroRecursoUtiMapper.cs
+++ b/Services/Mapping/RegistroRecursoUtiMapper.cs
@@ -1,0 +1,67 @@
+using DelCorp.Models;
+using DelCorp.Models.Local;
+using DelCorp.Models.Supabase;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DelCorp.Services.Mapping
+{
+    public static class RegistroRecursoUtiMapper
+    {
+        public static RegistroRecursoUti ToDto(this SupabaseRegistroRecursoUti supabase) => supabase == null ? null : new RegistroRecursoUti
+        {
+            Id = supabase.IdRegistroRecursoUti,
+            CreatedAt = supabase.CreatedAt,
+            FechaRecursoUti = supabase.FechaRecursoUti,
+            CantidadRecursosUti = supabase.CantidadRecursosUti,
+            PrecioUniRecursosUti = supabase.PrecioUniRecursosUti,
+            TotalRecursosUti = supabase.TotalRecursosUti,
+            IdRecurso = supabase.IdRecurso,
+            IdSubEtapa = supabase.IdSubEtapa,
+            IdUniMedida = supabase.IdUniMedida
+        };
+
+        public static RegistroRecursoUti ToDto(this LocalRegistroRecursoUti local) => local == null ? null : new RegistroRecursoUti
+        {
+            Id = local.ServerId ?? local.LocalId,
+            CreatedAt = local.CreatedAt,
+            FechaRecursoUti = local.FechaRecursoUti,
+            CantidadRecursosUti = local.CantidadRecursosUti,
+            PrecioUniRecursosUti = local.PrecioUniRecursosUti,
+            TotalRecursosUti = local.TotalRecursosUti,
+            IdRecurso = local.IdRecurso,
+            IdSubEtapa = local.IdSubEtapa,
+            IdUniMedida = local.IdUniMedida
+        };
+
+        public static SupabaseRegistroRecursoUti ToSupabase(this RegistroRecursoUti dto) => dto == null ? null : new SupabaseRegistroRecursoUti
+        {
+            IdRegistroRecursoUti = dto.Id,
+            CreatedAt = dto.CreatedAt,
+            FechaRecursoUti = dto.FechaRecursoUti,
+            CantidadRecursosUti = dto.CantidadRecursosUti,
+            PrecioUniRecursosUti = dto.PrecioUniRecursosUti,
+            TotalRecursosUti = dto.TotalRecursosUti,
+            IdRecurso = dto.IdRecurso,
+            IdSubEtapa = dto.IdSubEtapa,
+            IdUniMedida = dto.IdUniMedida
+        };
+
+        public static LocalRegistroRecursoUti ToLocal(this RegistroRecursoUti dto, bool isSynced = true) => dto == null ? null : new LocalRegistroRecursoUti
+        {
+            ServerId = dto.Id,
+            CreatedAt = dto.CreatedAt,
+            FechaRecursoUti = dto.FechaRecursoUti,
+            CantidadRecursosUti = dto.CantidadRecursosUti,
+            PrecioUniRecursosUti = dto.PrecioUniRecursosUti,
+            TotalRecursosUti = dto.TotalRecursosUti,
+            IdRecurso = dto.IdRecurso,
+            IdSubEtapa = dto.IdSubEtapa,
+            IdUniMedida = dto.IdUniMedida,
+            IsSynced = isSynced
+        };
+
+        public static List<RegistroRecursoUti> ToDtoList(this IEnumerable<SupabaseRegistroRecursoUti> supabaseList) => supabaseList.Select(s => s.ToDto()).ToList();
+        public static List<RegistroRecursoUti> ToDtoList(this IEnumerable<LocalRegistroRecursoUti> localList) => localList.Select(l => l.ToDto()).ToList();
+    }
+}

--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -1646,5 +1646,78 @@ namespace DelCorp.Services
 
             return syncedDto ?? actividad; // Devolver el DTO sincronizado si está disponible, sino el original (que ahora podría tener ID)
         }
+
+        // ----- RegistroRecursoUti -----
+        public async Task<IEnumerable<RegistroRecursoUti>> GetRegistrosRecursoUtiBySubEtapaIdAsync(long subEtapaId)
+        {
+            var localItems = await _localDatabase.GetRegistrosRecursoUtiBySubEtapaIdAsync(subEtapaId);
+            var dtos = localItems.Select(l => RegistroRecursoUtiMapper.ToDto(l)).ToList();
+
+            var recursos = await GetRecursosAsync();
+            var unis = await GetUniMedReAsync();
+            foreach (var dto in dtos)
+            {
+                if (dto.IdRecurso.HasValue)
+                    dto.Recurso = recursos.FirstOrDefault(r => r.Id == dto.IdRecurso.Value);
+                if (dto.IdUniMedida.HasValue)
+                    dto.UniMedRe = unis.FirstOrDefault(u => u.Id == dto.IdUniMedida.Value);
+            }
+
+            return dtos.OrderByDescending(d => d.CreatedAt);
+        }
+
+        public async Task<RegistroRecursoUti> SaveRegistroRecursoUtiAsync(RegistroRecursoUti registro)
+        {
+            registro.CreatedAt = DateTime.UtcNow;
+            if (registro.CantidadRecursosUti.HasValue && registro.PrecioUniRecursosUti.HasValue)
+                registro.TotalRecursosUti = registro.CantidadRecursosUti * registro.PrecioUniRecursosUti;
+
+            var local = RegistroRecursoUtiMapper.ToLocal(registro, isSynced: false);
+            if (registro.Id == 0) local.LocalId = 0;
+            await _localDatabase.SaveRegistroRecursoUtiAsync(local);
+            registro.Id = local.ServerId ?? local.LocalId;
+            return registro;
+        }
+
+        public async Task DeleteRegistroRecursoUtiAsync(long registroId)
+        {
+            var localItem = await _localDatabase.GetLocalRegistroRecursoUtiByServerIdAsync(registroId)
+                            ?? await _localDatabase.GetLocalRegistroRecursoUtiByLocalIdAsync(registroId);
+            if (localItem != null)
+            {
+                await _localDatabase.DeleteRegistroRecursoUtiByLocalIdAsync(localItem.LocalId);
+            }
+        }
+
+        public async Task UpdateExecutionTotalsForSubEtapaAsync(long subEtapaId)
+        {
+            var registros = await GetRegistrosRecursoUtiBySubEtapaIdAsync(subEtapaId);
+            decimal totalSub = registros.Sum(r => r.TotalRecursosUti ?? 0m);
+
+            var localSub = await _localDatabase.GetLocalSubEtapaByIdAsync(subEtapaId);
+            if (localSub != null)
+            {
+                localSub.MontoEjeSubEtapa = totalSub;
+                await _localDatabase.SaveSubEtapaAsync(localSub);
+
+                var subEtapas = await _localDatabase.GetSubEtapasByEtapaIdAsync(localSub.IdEtapa);
+                decimal totalEtapa = subEtapas.Sum(se => se.MontoEjeSubEtapa ?? 0m);
+                var etapa = await _localDatabase.GetEtapaByIdAsync(localSub.IdEtapa);
+                if (etapa != null)
+                {
+                    etapa.MontoEjeEtapa = totalEtapa;
+                    await _localDatabase.SaveEtapaAsync(etapa);
+
+                    var etapas = await _localDatabase.GetEtapasByPresupuestoIdAsync(etapa.IdPresupuesto);
+                    decimal totalPres = etapas.Sum(e => e.MontoEjeEtapa ?? 0m);
+                    var presupuesto = await _localDatabase.GetPresupuestoByIdAsync(etapa.IdPresupuesto);
+                    if (presupuesto != null)
+                    {
+                        presupuesto.MontoEjePresupuesto = totalPres;
+                        await _localDatabase.SavePresupuestoAsync(presupuesto);
+                    }
+                }
+            }
+        }
     }
 }

--- a/ViewModels/ProjectDetailViewModel.cs
+++ b/ViewModels/ProjectDetailViewModel.cs
@@ -20,12 +20,17 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
     private Project _project;
 
     [ObservableProperty]
-    private ObservableCollection<Presupuesto> _presupuestos;
+    private ObservableCollection<Presupuesto> _presupuestos = new();
+
+    [ObservableProperty]
+    private Presupuesto _selectedPresupuesto;
+    
+    [ObservableProperty]
+    private ObservableCollection<Etapa> _etapasDelPresupuesto = new();
 
     public ProjectDetailViewModel(IDataService dataService)
     {
         _dataService = dataService;
-        _presupuestos = new ObservableCollection<Presupuesto>();
     }
 
     public async void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -51,15 +56,12 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
 
         // Cargar presupuestos del proyecto
         await LoadPresupuestos(id);
+        if (Presupuestos.Any())
+        {
+            SelectedPresupuesto = Presupuestos.First();
+        }
 
-        if (Project.LatitudProyecto != null && Project.LongitudProyecto != null)
-        {
-            VisibleMap = true;
-        }
-        else
-        {
-            VisibleMap = false;
-        }
+        VisibleMap = Project.LatitudProyecto != null && Project.LongitudProyecto != null;
     }
 
     // Método para abrir ubicación en mapa si está disponible
@@ -129,5 +131,31 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
                 "OK"
             );
         }
+    }
+
+    async partial void OnSelectedPresupuestoChanged(Presupuesto value)
+    {
+        EtapasDelPresupuesto.Clear();
+        if (value != null)
+        {
+            await LoadEtapasForPresupuesto(value.Id);
+        }
+    }
+
+    private async Task LoadEtapasForPresupuesto(long presupuestoId)
+    {
+        var etapas = await _dataService.GetEtapasByPresupuestoId((int)presupuestoId);
+        EtapasDelPresupuesto.Clear();
+        foreach (var etapa in etapas)
+        {
+            EtapasDelPresupuesto.Add(etapa);
+        }
+    }
+
+    [RelayCommand]
+    private async Task NavigateToRegistrarEjecucion(SubEtapa subEtapa)
+    {
+        if (subEtapa == null) return;
+        await Shell.Current.GoToAsync($"{nameof(RegistrarRecursoEjecutadoPage)}?idSubEtapa={subEtapa.Id}");
     }
 }

--- a/ViewModels/RegistrarRecursoEjecutadoViewModel.cs
+++ b/ViewModels/RegistrarRecursoEjecutadoViewModel.cs
@@ -1,0 +1,185 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DelCorp.Models;
+using DelCorp.Services;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DelCorp.ViewModels
+{
+    [QueryProperty(nameof(IdSubEtapa), "idSubEtapa")]
+    public partial class RegistrarRecursoEjecutadoViewModel : ObservableObject
+    {
+        private readonly IDataService _dataService;
+
+        [ObservableProperty] private long _idSubEtapa;
+        [ObservableProperty] private bool _isBusy;
+        [ObservableProperty] private string _errorMessage;
+
+        // Form properties
+        [ObservableProperty] private DateTime _fechaRecurso = DateTime.Today;
+        [ObservableProperty] private CategoriaRec _selectedCategoriaRec;
+        [ObservableProperty] private Recurso _selectedRecurso;
+        [ObservableProperty] private UniMedRe _selectedUniMedRe;
+        [ObservableProperty] private decimal? _cantidad;
+        [ObservableProperty] private decimal? _precioUnitario;
+        [ObservableProperty] private decimal? _totalCalculado;
+
+        // Collections
+        [ObservableProperty] private ObservableCollection<RegistroRecursoUti> _recursosEjecutados = new();
+        [ObservableProperty] private ObservableCollection<CategoriaRec> _disponibleCategoriasRec = new();
+        [ObservableProperty] private ObservableCollection<Recurso> _disponibleRecursos = new();
+        [ObservableProperty] private ObservableCollection<UniMedRe> _disponibleUniMedRe = new();
+
+        public bool IsNotBusy => !IsBusy;
+        public bool HasError => !string.IsNullOrEmpty(ErrorMessage);
+
+        public RegistrarRecursoEjecutadoViewModel(IDataService dataService)
+        {
+            _dataService = dataService;
+        }
+
+        async partial void OnIdSubEtapaChanged(long value)
+        {
+            if (value > 0)
+            {
+                await LoadInitialDataAsync();
+            }
+        }
+
+        async partial void OnSelectedCategoriaRecChanged(CategoriaRec value)
+        {
+            await LoadRecursosAsync();
+        }
+
+        partial void OnCantidadChanged(decimal? value) => CalculateTotal();
+        partial void OnPrecioUnitarioChanged(decimal? value) => CalculateTotal();
+        partial void OnErrorMessageChanged(string value) => OnPropertyChanged(nameof(HasError));
+
+        private void CalculateTotal()
+        {
+            TotalCalculado = Cantidad.HasValue && PrecioUnitario.HasValue ? Cantidad * PrecioUnitario : null;
+        }
+
+        private async Task LoadInitialDataAsync()
+        {
+            IsBusy = true;
+            await LoadCategoriasRecAsync();
+            await LoadRecursosAsync();
+            await LoadUniMedReAsync();
+            await LoadRecursosEjecutadosAsync();
+            IsBusy = false;
+        }
+
+        private async Task LoadRecursosEjecutadosAsync()
+        {
+            var items = await _dataService.GetRegistrosRecursoUtiBySubEtapaIdAsync(IdSubEtapa);
+            RecursosEjecutados.Clear();
+            foreach (var item in items)
+            {
+                RecursosEjecutados.Add(item);
+            }
+        }
+
+        private async Task LoadCategoriasRecAsync()
+        {
+            var items = await _dataService.GetCategoriasRecAsync();
+            DisponibleCategoriasRec.Clear();
+            foreach (var item in items) DisponibleCategoriasRec.Add(item);
+        }
+
+        private async Task LoadRecursosAsync()
+        {
+            var items = await _dataService.GetRecursosAsync(SelectedCategoriaRec?.Id);
+            DisponibleRecursos.Clear();
+            foreach (var item in items) DisponibleRecursos.Add(item);
+        }
+
+        private async Task LoadUniMedReAsync()
+        {
+            var items = await _dataService.GetUniMedReAsync();
+            DisponibleUniMedRe.Clear();
+            foreach (var item in items) DisponibleUniMedRe.Add(item);
+        }
+
+
+        [RelayCommand]
+        private async Task AddRecurso()
+        {
+            if (SelectedRecurso == null || SelectedUniMedRe == null || !Cantidad.HasValue || !PrecioUnitario.HasValue)
+            {
+                ErrorMessage = "Por favor, complete todos los campos.";
+                return;
+            }
+
+            IsBusy = true;
+            ErrorMessage = string.Empty;
+
+            try
+            {
+                var newRegistro = new RegistroRecursoUti
+                {
+                    FechaRecursoUti = FechaRecurso,
+                    IdSubEtapa = IdSubEtapa,
+                    IdRecurso = SelectedRecurso.Id,
+                    IdUniMedida = SelectedUniMedRe.Id,
+                    CantidadRecursosUti = Cantidad,
+                    PrecioUniRecursosUti = PrecioUnitario,
+                    TotalRecursosUti = TotalCalculado,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                var savedItem = await _dataService.SaveRegistroRecursoUtiAsync(newRegistro);
+
+                savedItem.Recurso = SelectedRecurso;
+                savedItem.UniMedRe = SelectedUniMedRe;
+                RecursosEjecutados.Add(savedItem);
+
+                await UpdateExecutionTotalsAsync();
+
+                // Clear form
+                SelectedRecurso = null;
+                SelectedUniMedRe = null;
+                Cantidad = null;
+                PrecioUnitario = null;
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = $"Error al guardar: {ex.Message}";
+                Debug.WriteLine(ErrorMessage);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        [RelayCommand]
+        private async Task DeleteRecurso(RegistroRecursoUti registro)
+        {
+            if (registro == null) return;
+            IsBusy = true;
+            try
+            {
+                await _dataService.DeleteRegistroRecursoUtiAsync(registro.Id);
+                RecursosEjecutados.Remove(registro);
+                await UpdateExecutionTotalsAsync();
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = $"Error al eliminar: {ex.Message}";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        private async Task UpdateExecutionTotalsAsync()
+        {
+            await _dataService.UpdateExecutionTotalsForSubEtapaAsync(IdSubEtapa);
+        }
+    }
+}

--- a/Views/ProjectDetailPage.xaml
+++ b/Views/ProjectDetailPage.xaml
@@ -1,131 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="DelCorp.Views.ProjectDetailPage"
-             xmlns:viewmodel="clr-namespace:DelCorp.ViewModels"
+             xmlns:viewmodels="clr-namespace:DelCorp.ViewModels"
              xmlns:models="clr-namespace:DelCorp.Models"
-             Title="Detalles del Proyecto"
-             x:DataType="viewmodel:ProjectDetailViewModel">
-
+             x:Class="DelCorp.Views.ProjectDetailPage"
+             x:DataType="viewmodels:ProjectDetailViewModel"
+             Title="{Binding Project.NombreProyecto}">
     <ScrollView>
-        <VerticalStackLayout Spacing="15" Padding="20">
-            <!-- Nombre del Proyecto -->
-            <Frame BorderColor="LightGray" Padding="15">
-                <VerticalStackLayout>
-                    <Label 
-                        Text="Nombre del Proyecto" 
-                        FontSize="16" 
-                        FontAttributes="Bold"/>
-                    <Label 
-                        Text="{Binding Project.NombreProyecto}" 
-                        FontSize="18"/>
-                </VerticalStackLayout>
-            </Frame>
+        <VerticalStackLayout Spacing="10" Padding="20">
+            <!-- Project Details -->
+            <Label Text="{Binding Project.NombreProyecto}" FontSize="Header" FontAttributes="Bold" />
+            <Label Text="{Binding Project.DescripcionProyecto}" />
+            <!-- ... otros detalles del proyecto ... -->
 
-            <!-- Fechas -->
-            <Frame BorderColor="LightGray" Padding="15">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,*">
-                    <Label 
-                        Grid.Row="0" Grid.Column="0" 
-                        Text="Fecha de Creación" 
-                        FontAttributes="Bold"/>
-                    <Label 
-                        Grid.Row="1" Grid.Column="0" 
-                        Text="{Binding Project.CreatedAt, StringFormat='{0:dd/MM/yyyy HH:mm}'}"/>
+            <!-- Budget Selection and Execution -->
+            <BoxView HeightRequest="1" Color="Gray" Margin="0,10" />
+            <Label Text="Ejecución de Presupuestos" FontSize="Title" FontAttributes="Bold"/>
 
-                    <Label 
-                        Grid.Row="0" Grid.Column="1" 
-                        Text="Fecha de Inicio" 
-                        FontAttributes="Bold"/>
-                    <Label 
-                        Grid.Row="1" Grid.Column="1" 
-                        Text="{Binding Project.FechaInicioProyecto, StringFormat='{0:dd/MM/yyyy}'}"
-                        TextColor="{StaticResource Primary}"/>
-
-                    <Label 
-                        Grid.Row="2" Grid.Column="0" 
-                        Text="Fecha de Fin" 
-                        FontAttributes="Bold"/>
-                    <Label 
-                        Grid.Row="3" Grid.Column="0" 
-                        Text="{Binding Project.FechaFinProyecto, StringFormat='{0:dd/MM/yyyy}'}"
-                        TextColor="{StaticResource Primary}"/>
-                </Grid>
-            </Frame>
-
-            <!-- Descripción -->
-            <Frame BorderColor="LightGray" Padding="15">
-                <VerticalStackLayout>
-                    <Label 
-                        Text="Descripción" 
-                        FontSize="16" 
-                        FontAttributes="Bold"/>
-                    <Label 
-                        Text="{Binding Project.DescripcionProyecto}"
-                        FontSize="14"/>
-                </VerticalStackLayout>
-            </Frame>
-
-            <!-- Ubicación -->
-            <Frame BorderColor="LightGray" Padding="15">
-                <VerticalStackLayout>
-                    <Label 
-                        Text="Dirección" 
-                        FontSize="16" 
-                        FontAttributes="Bold"/>
-                    <Label 
-                        Text="{Binding Project.DireccionProyecto}"
-                        FontSize="14"/>
-
-                    <Button 
-                        Text="Ver en Mapa" 
-                        Command="{Binding OpenLocationCommand}"
-                        IsVisible="{Binding VisibleMap}"
-                        Margin="0,10,0,0"/>
-                </VerticalStackLayout>
-            </Frame>
-
-            <CollectionView 
-                ItemsSource="{Binding Presupuestos}"
-                HeightRequest="300"
-                SelectionMode="None">
-                <CollectionView.EmptyView>
-                    <Label 
-                        Text="No hay presupuestos registrados" 
-                        HorizontalOptions="Center" 
-                        TextColor="Gray"/>
-                </CollectionView.EmptyView>
-
+            <Picker Title="Seleccione un Presupuesto"
+                    ItemsSource="{Binding Presupuestos}"
+                    ItemDisplayBinding="{Binding NombrePresupuesto}"
+                    SelectedItem="{Binding SelectedPresupuesto}"/>
+            
+            <CollectionView ItemsSource="{Binding EtapasDelPresupuesto}">
                 <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="models:Presupuesto">
-                        <Frame Margin="0,5" Padding="10" BorderColor="LightGray">
-                            <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto">
-                                <Label 
-                                    Grid.Row="0" Grid.Column="0"
-                                    Text="{Binding NombrePresupuesto}" 
-                                    FontAttributes="Bold"/>
-
-                                <Label 
-                                    Grid.Row="1" Grid.Column="0"
-                                    Text="Total Presupuesto:" 
-                                    FontSize="12"/>
-                                <Label 
-                                    Grid.Row="1" Grid.Column="1"
-                                    Text="{Binding TotalPresupuesto, StringFormat='C${0:N2}'}" 
-                                    FontAttributes="Bold"/>
-
-                                <Label 
-                                    Grid.Row="2" Grid.Column="0"
-                                    Text="Progreso:" 
-                                    FontSize="12"/>
-                                <Label 
-                                    Grid.Row="2" Grid.Column="1"
-                                    Text="{Binding ProgresoPresupuesto, StringFormat='{0:P0}'}" 
-                                    TextColor="{StaticResource Primary}"/>
-                            </Grid>
+                    <DataTemplate x:DataType="models:Etapa">
+                        <Frame Margin="0,5" Padding="10" BorderColor="LightGray" CornerRadius="5">
+                            <VerticalStackLayout Spacing="8">
+                                <Label Text="{Binding Actividad.NombreActividad}" FontAttributes="Bold" FontSize="Medium"/>
+                                
+                                <CollectionView ItemsSource="{Binding SubEtapas}">
+                                    <CollectionView.ItemTemplate>
+                                        <DataTemplate x:DataType="models:SubEtapa">
+                                            <Border StrokeShape="RoundRectangle 5" Stroke="Gainsboro" Padding="10" Margin="5,5,5,10">
+                                                <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto" RowSpacing="5">
+                                                    <Label Grid.Row="0" Grid.Column="0" Text="{Binding Actividad.NombreActividad}" FontAttributes="Italic"/>
+                                                    <Label Grid.Row="1" Grid.Column="0">
+                                                        <Label.FormattedText>
+                                                            <FormattedString>
+                                                                <Span Text="Monto Plan: "/>
+                                                                <Span Text="{Binding TotalSubEstapa, StringFormat='{0:C}'}" FontAttributes="Bold"/>
+                                                                <Span Text=" | Monto Ejec: "/>
+                                                                <Span Text="{Binding MontoEjeSubEtapa, StringFormat='{0:C}'}" FontAttributes="Bold"/>
+                                                            </FormattedString>
+                                                        </Label.FormattedText>
+                                                    </Label>
+                                                    <Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1" Text="Registrar Ejecución"
+                                                            Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:ProjectDetailViewModel}}, Path=NavigateToRegistrarEjecucionCommand}"
+                                                            CommandParameter="{Binding .}"
+                                                            VerticalOptions="Center"/>
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </CollectionView.ItemTemplate>
+                                </CollectionView>
+                            </VerticalStackLayout>
                         </Frame>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
+
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/Views/RegistrarRecursoEjecutadoPage.xaml
+++ b/Views/RegistrarRecursoEjecutadoPage.xaml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:DelCorp.ViewModels"
+             xmlns:models="clr-namespace:DelCorp.Models"
+             x:Class="DelCorp.Views.RegistrarRecursoEjecutadoPage"
+             x:DataType="viewmodels:RegistrarRecursoEjecutadoViewModel"
+             Title="Registrar Recurso Ejecutado">
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="15">
+            <!-- Formulario de Registro -->
+            <Label Text="Registrar Nuevo Recurso Ejecutado" FontSize="Large" FontAttributes="Bold" HorizontalOptions="Center"/>
+
+            <DatePicker Date="{Binding FechaRecurso}" />
+
+            <Picker Title="Seleccionar Categoría de Recurso"
+                    ItemsSource="{Binding DisponibleCategoriasRec}"
+                    ItemDisplayBinding="{Binding NombreCatRec}"
+                    SelectedItem="{Binding SelectedCategoriaRec}" />
+
+            <Picker Title="Seleccionar Recurso"
+                    ItemsSource="{Binding DisponibleRecursos}"
+                    ItemDisplayBinding="{Binding NombreRecurso}"
+                    SelectedItem="{Binding SelectedRecurso}" />
+
+            <Picker Title="Seleccionar Unidad de Medida"
+                    ItemsSource="{Binding DisponibleUniMedRe}"
+                    ItemDisplayBinding="{Binding NombreUniMedRe}"
+                    SelectedItem="{Binding SelectedUniMedRe}" />
+
+            <Entry Placeholder="Cantidad" Keyboard="Numeric" Text="{Binding Cantidad}" />
+            <Entry Placeholder="Precio Unitario" Keyboard="Numeric" Text="{Binding PrecioUnitario}" />
+
+            <Label Text="{Binding TotalCalculado, StringFormat='Total: {0:C}'}" HorizontalOptions="End" FontAttributes="Bold"/>
+
+            <Button Text="Agregar Recurso" Command="{Binding AddRecursoCommand}" IsEnabled="{Binding IsNotBusy}" />
+            <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" HorizontalOptions="Center" />
+            <Label Text="{Binding ErrorMessage}" TextColor="Red" IsVisible="{Binding HasError}" />
+
+            <!-- Lista de Recursos Ya Registrados -->
+            <Label Text="Recursos Registrados en esta Sub-Etapa" FontSize="Medium" FontAttributes="Bold" Margin="0,20,0,0"/>
+            <CollectionView ItemsSource="{Binding RecursosEjecutados}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:RegistroRecursoUti">
+                        <Frame Padding="10" Margin="0,5" CornerRadius="10" BorderColor="LightGray">
+                            <Grid RowSpacing="5">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Label Grid.Row="0" Grid.Column="0" FontAttributes="Bold">
+                                    <Label.FormattedText>
+                                        <FormattedString>
+                                            <Span Text="{Binding Recurso.NombreRecurso}" />
+                                            <Span Text=" (" />
+                                            <Span Text="{Binding FechaRecursoUti, StringFormat='{0:dd/MM/yyyy}'}" />
+                                            <Span Text=")" />
+                                        </FormattedString>
+                                    </Label.FormattedText>
+                                </Label>
+                                <Label Grid.Row="1" Grid.Column="0">
+                                    <Label.FormattedText>
+                                        <FormattedString>
+                                            <Span Text="{Binding CantidadRecursosUti}" />
+                                            <Span Text=" " />
+                                            <Span Text="{Binding UniMedRe.AbreviaturaUniMedRe}" />
+                                            <Span Text=" @ " />
+                                            <Span Text="{Binding PrecioUniRecursosUti, StringFormat='{0:C}'}" />
+                                            <Span Text=" = " />
+                                            <Span Text="{Binding TotalRecursosUti, StringFormat='{0:C}'}" FontAttributes="Bold" />
+                                        </FormattedString>
+                                    </Label.FormattedText>
+                                </Label>
+
+                                <Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1" Text="Eliminar"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:RegistrarRecursoEjecutadoViewModel}}, Path=DeleteRecursoCommand}"
+                                        CommandParameter="{Binding .}"
+                                        BackgroundColor="Red"
+                                        VerticalOptions="Center"/>
+                            </Grid>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Views/RegistrarRecursoEjecutadoPage.xaml.cs
+++ b/Views/RegistrarRecursoEjecutadoPage.xaml.cs
@@ -1,0 +1,12 @@
+using DelCorp.ViewModels;
+
+namespace DelCorp.Views;
+
+public partial class RegistrarRecursoEjecutadoPage : ContentPage
+{
+    public RegistrarRecursoEjecutadoPage(RegistrarRecursoEjecutadoViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}


### PR DESCRIPTION
## Summary
- model new `RegistroRecursoUti` entity with local and supabase versions
- wire new mapping utilities and database helpers
- add view model and page to register executed resources
- extend project detail page to open the new page
- update data service and offline service implementations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e8e52df4832baf0811927d6ee004