### PR TITLE
Implement registro recursos uti feature

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -14,6 +14,7 @@ namespace DelCorp
             RegisterForRoute<RegistrarEtapaPage>();
             RegisterForRoute<RegistrarSubEtapaPage>();
             RegisterForRoute<RegistrarRecursoUtiPage>();
+            RegisterForRoute<RegistroRecursosPage>();
         }
 
         protected void RegisterForRoute<T>()

--- a/DelCorp.csproj
+++ b/DelCorp.csproj
@@ -102,12 +102,15 @@
 	  <MauiXaml Update="Views\RegistrarPresupuestoPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\RegistrarRecursoUtiPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\RegistrarSubEtapaPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+          <MauiXaml Update="Views\RegistrarRecursoUtiPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\RegistroRecursosPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\RegistrarSubEtapaPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
 	  <MauiXaml Update="Views\UserProfilePage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -52,6 +52,7 @@ namespace DelCorp
             builder.Services.AddTransient<RegistrarEtapaViewModel>();
             builder.Services.AddTransient<RegistrarSubEtapaViewModel>();
             builder.Services.AddTransient<RegistrarRecursoUtiViewModel>();
+            builder.Services.AddTransient<RegistroRecursosViewModel>();
 
             // Views
             builder.Services.AddSingleton<ProjectPage>();
@@ -65,6 +66,7 @@ namespace DelCorp
             builder.Services.AddTransient<RegistrarEtapaPage>();
             builder.Services.AddTransient<RegistrarSubEtapaPage>();
             builder.Services.AddTransient<RegistrarRecursoUtiPage>();
+            builder.Services.AddTransient<RegistroRecursosPage>();
 
             // Servicios
             builder.Services.AddSingleton<IDataService, OfflineFirstDataService>();

--- a/Models/Local/LocalRegistroRecursoUti.cs
+++ b/Models/Local/LocalRegistroRecursoUti.cs
@@ -1,0 +1,21 @@
+using SQLite;
+
+namespace DelCorp.Models.Local
+{
+    [Table("LocalRegistroRecursosUti")]
+    public class LocalRegistroRecursoUti
+    {
+        [PrimaryKey, AutoIncrement]
+        public long LocalId { get; set; }
+        public long? ServerId { get; set; }
+        public bool IsSynced { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? FechaRecursoUti { get; set; }
+        public decimal? CantidadRecursosUti { get; set; }
+        public decimal? PrecioUniRecursosUti { get; set; }
+        public decimal? TotalRecursosUti { get; set; }
+        public long? IdRecurso { get; set; }
+        public long? IdSubEtapa { get; set; }
+        public long? IdUniMedida { get; set; }
+    }
+}

--- a/Models/RegistroRecursoUti.cs
+++ b/Models/RegistroRecursoUti.cs
@@ -1,0 +1,18 @@
+namespace DelCorp.Models
+{
+    public class RegistroRecursoUti
+    {
+        public long IdRegistroRecursoUti { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? FechaRecursoUti { get; set; }
+        public decimal? CantidadRecursosUti { get; set; }
+        public decimal? PrecioUniRecursosUti { get; set; }
+        public decimal? TotalRecursosUti { get; set; }
+        public long? IdRecurso { get; set; }
+        public long? IdSubEtapa { get; set; }
+        public long? IdUniMedida { get; set; }
+
+        public Recurso? Recurso { get; set; }
+        public UniMedRe? UniMedRe { get; set; }
+    }
+}

--- a/Models/Supabase/SupabaseRegistroRecursoUti.cs
+++ b/Models/Supabase/SupabaseRegistroRecursoUti.cs
@@ -1,0 +1,36 @@
+using Postgrest.Attributes;
+using Postgrest.Models;
+
+namespace DelCorp.Models.Supabase
+{
+    [Table("registro_recursos_uti")]
+    public class SupabaseRegistroRecursoUti : BaseModel
+    {
+        [PrimaryKey("id_registro_recurso_uti", false)]
+        public long IdRegistroRecursoUti { get; set; }
+
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [Column("fecha_recurso_uti")]
+        public DateTime? FechaRecursoUti { get; set; }
+
+        [Column("cantidad_recursos_uti")]
+        public decimal? CantidadRecursosUti { get; set; }
+
+        [Column("precio_uni_recursos_uti")]
+        public decimal? PrecioUniRecursosUti { get; set; }
+
+        [Column("total_recursos_uti")]
+        public decimal? TotalRecursosUti { get; set; }
+
+        [Column("id_recurso")]
+        public long? IdRecurso { get; set; }
+
+        [Column("id_sub_etapa")]
+        public long? IdSubEtapa { get; set; }
+
+        [Column("id_uni_medida")]
+        public long? IdUniMedida { get; set; }
+    }
+}

--- a/Services/IDataService.cs
+++ b/Services/IDataService.cs
@@ -49,6 +49,11 @@ namespace DelCorp.Services
         Task<RecursoUti> SaveRecursoUtiAsync(RecursoUti recursoUti);
         Task DeleteRecursoUtiAsync(long recursoUtiId);
 
+        // Registro de Recursos Utilizados
+        Task<IEnumerable<RegistroRecursoUti>> GetRegistroRecursosBySubEtapaIdAsync(long subEtapaId);
+        Task<RegistroRecursoUti> SaveRegistroRecursoAsync(RegistroRecursoUti registro);
+        Task DeleteRegistroRecursoAsync(long registroId);
+
         // Actividades categoría
         Task<IEnumerable<CategoriaActividad>> GetCategoriasActividadAsync();
         Task SaveCategoriaActividadAsync(CategoriaActividad categoriaActividad); // Principalmente para admin/sincronización

--- a/Services/LocalDatabaseService.cs
+++ b/Services/LocalDatabaseService.cs
@@ -22,6 +22,7 @@ public class LocalDatabaseService : IDisposable
         _database.CreateTableAsync<LocalUniMedRe>().Wait();
         _database.CreateTableAsync<LocalRecurso>().Wait();
         _database.CreateTableAsync<LocalRecursoUti>().Wait();
+        _database.CreateTableAsync<LocalRegistroRecursoUti>().Wait();
         _database.CreateTableAsync<LocalCategoriaActividad>().Wait();
         _database.CreateTableAsync<LocalActividad>().Wait();
     }
@@ -393,6 +394,27 @@ public class LocalDatabaseService : IDisposable
 
     public async Task<List<LocalRecursoUti>> GetUnsyncedRecursosUtiAsync() =>
         await _database.Table<LocalRecursoUti>().Where(r => !r.IsSynced).ToListAsync();
+
+    // RegistroRecursoUti
+    public async Task<List<LocalRegistroRecursoUti>> GetRegistroRecursosBySubEtapaIdAsync(long subEtapaId) =>
+        await _database.Table<LocalRegistroRecursoUti>().Where(r => r.IdSubEtapa == subEtapaId).ToListAsync();
+
+    public async Task<LocalRegistroRecursoUti?> GetLocalRegistroRecursoByServerIdAsync(long serverId) =>
+        await _database.Table<LocalRegistroRecursoUti>().FirstOrDefaultAsync(r => r.ServerId == serverId);
+
+    public async Task SaveRegistroRecursoAsync(LocalRegistroRecursoUti item)
+    {
+        if (item.LocalId != 0)
+            await _database.UpdateAsync(item);
+        else
+            await _database.InsertAsync(item);
+    }
+
+    public async Task DeleteRegistroRecursoAsync(long localId) =>
+        await _database.Table<LocalRegistroRecursoUti>().DeleteAsync(r => r.LocalId == localId);
+
+    public async Task<List<LocalRegistroRecursoUti>> GetUnsyncedRegistroRecursosAsync() =>
+        await _database.Table<LocalRegistroRecursoUti>().Where(r => !r.IsSynced).ToListAsync();
 
     // Para LocalCategoriaActividad
     public async Task<List<LocalCategoriaActividad>> GetCategoriasActividadAsync() =>

--- a/Services/Mapping/RegistroRecursoUtiMapper.cs
+++ b/Services/Mapping/RegistroRecursoUtiMapper.cs
@@ -1,0 +1,62 @@
+using DelCorp.Models;
+using DelCorp.Models.Local;
+using DelCorp.Models.Supabase;
+
+namespace DelCorp.Services.Mapping
+{
+    public static class RegistroRecursoUtiMapper
+    {
+        public static RegistroRecursoUti ToDto(this SupabaseRegistroRecursoUti s) => s == null ? null : new RegistroRecursoUti
+        {
+            IdRegistroRecursoUti = s.IdRegistroRecursoUti,
+            CreatedAt = s.CreatedAt,
+            FechaRecursoUti = s.FechaRecursoUti,
+            CantidadRecursosUti = s.CantidadRecursosUti,
+            PrecioUniRecursosUti = s.PrecioUniRecursosUti,
+            TotalRecursosUti = s.TotalRecursosUti,
+            IdRecurso = s.IdRecurso,
+            IdSubEtapa = s.IdSubEtapa,
+            IdUniMedida = s.IdUniMedida
+        };
+
+        public static RegistroRecursoUti ToDto(this LocalRegistroRecursoUti l) => l == null ? null : new RegistroRecursoUti
+        {
+            IdRegistroRecursoUti = l.ServerId ?? l.LocalId,
+            CreatedAt = l.CreatedAt,
+            FechaRecursoUti = l.FechaRecursoUti,
+            CantidadRecursosUti = l.CantidadRecursosUti,
+            PrecioUniRecursosUti = l.PrecioUniRecursosUti,
+            TotalRecursosUti = l.TotalRecursosUti,
+            IdRecurso = l.IdRecurso,
+            IdSubEtapa = l.IdSubEtapa,
+            IdUniMedida = l.IdUniMedida
+        };
+
+        public static SupabaseRegistroRecursoUti ToSupabase(this RegistroRecursoUti d) => d == null ? null : new SupabaseRegistroRecursoUti
+        {
+            IdRegistroRecursoUti = d.IdRegistroRecursoUti,
+            CreatedAt = d.CreatedAt,
+            FechaRecursoUti = d.FechaRecursoUti,
+            CantidadRecursosUti = d.CantidadRecursosUti,
+            PrecioUniRecursosUti = d.PrecioUniRecursosUti,
+            TotalRecursosUti = d.TotalRecursosUti,
+            IdRecurso = d.IdRecurso,
+            IdSubEtapa = d.IdSubEtapa,
+            IdUniMedida = d.IdUniMedida
+        };
+
+        public static LocalRegistroRecursoUti ToLocal(this RegistroRecursoUti d, bool isSynced = true) => d == null ? null : new LocalRegistroRecursoUti
+        {
+            ServerId = d.IdRegistroRecursoUti,
+            CreatedAt = d.CreatedAt,
+            FechaRecursoUti = d.FechaRecursoUti,
+            CantidadRecursosUti = d.CantidadRecursosUti,
+            PrecioUniRecursosUti = d.PrecioUniRecursosUti,
+            TotalRecursosUti = d.TotalRecursosUti,
+            IdRecurso = d.IdRecurso,
+            IdSubEtapa = d.IdSubEtapa,
+            IdUniMedida = d.IdUniMedida,
+            IsSynced = isSynced
+        };
+    }
+}

--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -1392,6 +1392,80 @@ namespace DelCorp.Services
             }
         }
 
+        // RegistroRecursoUti
+        public async Task<IEnumerable<RegistroRecursoUti>> GetRegistroRecursosBySubEtapaIdAsync(long subEtapaId)
+        {
+            var localItems = await _localDatabase.GetRegistroRecursosBySubEtapaIdAsync(subEtapaId);
+            var dtos = localItems.Select(l => l.ToDto()).ToList();
+
+            var allRecursos = await GetRecursosAsync();
+            var allUniMedRe = await GetUniMedReAsync();
+            foreach (var dto in dtos)
+            {
+                if (dto.IdRecurso.HasValue)
+                    dto.Recurso = allRecursos.FirstOrDefault(r => r.Id == dto.IdRecurso.Value);
+                if (dto.IdUniMedida.HasValue)
+                    dto.UniMedRe = allUniMedRe.FirstOrDefault(u => u.Id == dto.IdUniMedida.Value);
+            }
+            return dtos;
+        }
+
+        public async Task<RegistroRecursoUti> SaveRegistroRecursoAsync(RegistroRecursoUti registro)
+        {
+            var local = registro.ToLocal(isSynced: false);
+            if (registro.IdRegistroRecursoUti == 0) local.LocalId = 0;
+
+            await _localDatabase.SaveRegistroRecursoAsync(local);
+
+            if (_connectivity.NetworkAccess == NetworkAccess.Internet)
+            {
+                var supabaseModel = registro.ToSupabase();
+                if (local.ServerId == null) supabaseModel.IdRegistroRecursoUti = default;
+
+                var response = await _supabaseClient.From<SupabaseRegistroRecursoUti>().Upsert(supabaseModel);
+                var synced = response.Models.FirstOrDefault();
+                if (synced != null)
+                {
+                    local.ServerId = synced.IdRegistroRecursoUti;
+                    local.IsSynced = true;
+                    await _localDatabase.SaveRegistroRecursoAsync(local);
+                    registro = synced.ToDto();
+                }
+            }
+
+            await UpdateSubEtapaMontoEjecutado(registro.IdSubEtapa!.Value);
+            return registro;
+        }
+
+        public async Task DeleteRegistroRecursoAsync(long registroId)
+        {
+            var localItem = await _localDatabase.GetLocalRegistroRecursoByServerIdAsync(registroId);
+            if (localItem != null)
+            {
+                await _localDatabase.DeleteRegistroRecursoAsync(localItem.LocalId);
+                if (_connectivity.NetworkAccess == NetworkAccess.Internet && localItem.ServerId.HasValue)
+                {
+                    await _supabaseClient.From<SupabaseRegistroRecursoUti>()
+                                         .Filter("id_registro_recurso_uti", Postgrest.Constants.Operator.Equals, localItem.ServerId.Value)
+                                         .Delete();
+                }
+                await UpdateSubEtapaMontoEjecutado(localItem.IdSubEtapa!.Value);
+            }
+        }
+
+        private async Task UpdateSubEtapaMontoEjecutado(long subEtapaId)
+        {
+            var recursosRegistrados = await GetRegistroRecursosBySubEtapaIdAsync(subEtapaId);
+            decimal nuevoMontoEjecutado = recursosRegistrados.Sum(r => r.TotalRecursosUti ?? 0M);
+
+            var subEtapa = await GetSubEtapaByIdAsync(subEtapaId);
+            if (subEtapa != null)
+            {
+                subEtapa.MontoEjeSubEtapa = nuevoMontoEjecutado;
+                await SaveSubEtapa(subEtapa);
+            }
+        }
+
         // --- Implementación para CategoriasActividad ---
         public async Task<IEnumerable<CategoriaActividad>> GetCategoriasActividadAsync()
         {

--- a/ViewModels/ProjectDetailViewModel.cs
+++ b/ViewModels/ProjectDetailViewModel.cs
@@ -130,4 +130,11 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
             );
         }
     }
+
+    [RelayCommand]
+    private async Task SelectPresupuesto(Presupuesto presupuesto)
+    {
+        if (presupuesto == null) return;
+        await Shell.Current.GoToAsync($"{nameof(RegistrarEtapaPage)}?id={presupuesto.Id}");
+    }
 }

--- a/ViewModels/RegistrarSubEtapaViewModel.cs
+++ b/ViewModels/RegistrarSubEtapaViewModel.cs
@@ -419,6 +419,13 @@ public partial class RegistrarSubEtapaViewModel : ObservableObject, IQueryAttrib
         }
     }
 
+    [RelayCommand]
+    private async Task NavigateToRegistroRecursos(SubEtapa subEtapa)
+    {
+        if (subEtapa == null) return;
+        await Shell.Current.GoToAsync($"{nameof(RegistroRecursosPage)}?idSubEtapa={subEtapa.Id}");
+    }
+
     // --- MÉTODOS Y COMANDOS PARA REORDENAMIENTO OPTIMIZADO DE SUBETAPAS ---
     private void LocalRenumberSubEtapas()
     {

--- a/ViewModels/RegistroRecursosViewModel.cs
+++ b/ViewModels/RegistroRecursosViewModel.cs
@@ -1,0 +1,96 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DelCorp.Models;
+using DelCorp.Services;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+namespace DelCorp.ViewModels
+{
+    [QueryProperty(nameof(IdSubEtapa), "idSubEtapa")]
+    public partial class RegistroRecursosViewModel : ObservableObject
+    {
+        private readonly IDataService _dataService;
+
+        [ObservableProperty] private long _idSubEtapa;
+        [ObservableProperty] private SubEtapa _currentSubEtapa;
+        [ObservableProperty] private bool _isBusy;
+
+        [ObservableProperty] private ObservableCollection<RegistroRecursoUti> _recursosRegistrados;
+        [ObservableProperty] private ObservableCollection<Recurso> _disponibleRecursos;
+        [ObservableProperty] private ObservableCollection<UniMedRe> _disponibleUniMedRe;
+
+        [ObservableProperty] private DateTime _fecha = DateTime.Today;
+        [ObservableProperty] private Recurso _selectedRecurso;
+        [ObservableProperty] private UniMedRe _selectedUniMedRe;
+        [ObservableProperty] private decimal? _cantidad;
+        [ObservableProperty] private decimal? _precioUnitario;
+        [ObservableProperty] private decimal? _total;
+
+        public RegistroRecursosViewModel(IDataService dataService)
+        {
+            _dataService = dataService;
+            RecursosRegistrados = new();
+            DisponibleRecursos = new();
+            DisponibleUniMedRe = new();
+        }
+
+        partial void OnIdSubEtapaChanged(long value) { _ = LoadDataAsync(); }
+        partial void OnCantidadChanged(decimal? value) => CalculateTotal();
+        partial void OnPrecioUnitarioChanged(decimal? value) => CalculateTotal();
+
+        private void CalculateTotal()
+        {
+            Total = (Cantidad ?? 0) * (PrecioUnitario ?? 0);
+        }
+
+        private async Task LoadDataAsync()
+        {
+            IsBusy = true;
+            CurrentSubEtapa = await _dataService.GetSubEtapaByIdAsync(IdSubEtapa);
+            var recursos = await _dataService.GetRecursosAsync();
+            var unidades = await _dataService.GetUniMedReAsync();
+
+            DisponibleRecursos.Clear();
+            foreach (var r in recursos) DisponibleRecursos.Add(r);
+
+            DisponibleUniMedRe.Clear();
+            foreach (var u in unidades) DisponibleUniMedRe.Add(u);
+
+            await LoadRegistrosAsync();
+            IsBusy = false;
+        }
+
+        private async Task LoadRegistrosAsync()
+        {
+            var registros = await _dataService.GetRegistroRecursosBySubEtapaIdAsync(IdSubEtapa);
+            RecursosRegistrados.Clear();
+            foreach (var r in registros) RecursosRegistrados.Add(r);
+        }
+
+        [RelayCommand]
+        private async Task GuardarRegistro()
+        {
+            if (SelectedRecurso == null || SelectedUniMedRe == null || Cantidad == null || PrecioUnitario == null)
+            {
+                await Shell.Current.DisplayAlert("Error", "Todos los campos son requeridos.", "OK");
+                return;
+            }
+            IsBusy = true;
+            var registro = new RegistroRecursoUti
+            {
+                IdSubEtapa = IdSubEtapa,
+                IdRecurso = SelectedRecurso.Id,
+                IdUniMedida = SelectedUniMedRe.Id,
+                FechaRecursoUti = Fecha,
+                CantidadRecursosUti = Cantidad,
+                PrecioUniRecursosUti = PrecioUnitario,
+                TotalRecursosUti = Total,
+                CreatedAt = DateTime.UtcNow
+            };
+            await _dataService.SaveRegistroRecursoAsync(registro);
+            await LoadRegistrosAsync();
+            IsBusy = false;
+        }
+    }
+}

--- a/Views/ProjectDetailPage.xaml
+++ b/Views/ProjectDetailPage.xaml
@@ -98,6 +98,11 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="models:Presupuesto">
                         <Frame Margin="0,5" Padding="10" BorderColor="LightGray">
+                            <Frame.GestureRecognizers>
+                                <TapGestureRecognizer 
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodel:ProjectDetailViewModel}}, Path=SelectPresupuestoCommand}"
+                                    CommandParameter="{Binding .}"/>
+                            </Frame.GestureRecognizers>
                             <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto">
                                 <Label 
                                     Grid.Row="0" Grid.Column="0"

--- a/Views/RegistrarSubEtapaPage.xaml
+++ b/Views/RegistrarSubEtapaPage.xaml
@@ -75,8 +75,9 @@
                                 <Label Grid.Row="1" Grid.Column="0" Text="{Binding CantidadSubEtapa, StringFormat='Cantidad: {0:N2}'}" />
                                 <Label Grid.Row="2" Grid.Column="0" Text="{Binding TotalSubEstapa, StringFormat='Total Calculado: C{0:C}'}" />
 
-                                <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Text="Añadir/Ver Recursos"
-                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:RegistrarSubEtapaViewModel}}, Path=NavigateToRegistrarRecursosCommand}"
+                                <Label Grid.Row="3" Grid.Column="0" Text="{Binding MontoEjeSubEtapa, StringFormat='Ejecutado: {0:C}'}" TextColor="Green" />
+                                <Button Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" Text="Registrar Uso de Recursos"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:RegistrarSubEtapaViewModel}}, Path=NavigateToRegistroRecursosCommand}"
                                         CommandParameter="{Binding .}" Margin="0,5,0,0"/>
                             </Grid>
                         </Frame>

--- a/Views/RegistroRecursosPage.xaml
+++ b/Views/RegistroRecursosPage.xaml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="DelCorp.Views.RegistroRecursosPage"
+             xmlns:vm="clr-namespace:DelCorp.ViewModels"
+             xmlns:converters="clr-namespace:DelCorp.Converters"
+             xmlns:models="clr-namespace:DelCorp.Models"
+             x:DataType="vm:RegistroRecursosViewModel"
+             Title="Registro de Recursos Utilizados">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:InverseBoolConverter x:Key="InverseBoolConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <VerticalStackLayout Spacing="10" Padding="15">
+        <Label Text="{Binding CurrentSubEtapa.Actividad.NombreActividad}" FontSize="Large" FontAttributes="Bold"/>
+
+        <Frame Padding="10" CornerRadius="10">
+            <VerticalStackLayout Spacing="8">
+                <Label Text="Añadir Recurso Utilizado" FontSize="Medium"/>
+                <DatePicker Date="{Binding Fecha}" />
+                <Picker Title="Seleccionar Recurso" ItemsSource="{Binding DisponibleRecursos}" ItemDisplayBinding="{Binding NombreRecurso}" SelectedItem="{Binding SelectedRecurso}" />
+                <Picker Title="Unidad de Medida" ItemsSource="{Binding DisponibleUniMedRe}" ItemDisplayBinding="{Binding AbreviaturaUniMedRe}" SelectedItem="{Binding SelectedUniMedRe}" />
+                <Entry Placeholder="Cantidad" Keyboard="Numeric" Text="{Binding Cantidad}" />
+                <Entry Placeholder="Precio Unitario" Keyboard="Numeric" Text="{Binding PrecioUnitario}" />
+                <Label Text="{Binding Total, StringFormat='Total: {0:C}'}" FontAttributes="Bold"/>
+                <Button Text="Guardar Recurso" Command="{Binding GuardarRegistroCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource InverseBoolConverter}}"/>
+            </VerticalStackLayout>
+        </Frame>
+
+        <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
+
+        <CollectionView ItemsSource="{Binding RecursosRegistrados}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:RegistroRecursoUti" xmlns:models="clr-namespace:DelCorp.Models">
+                    <Frame Margin="0,5" Padding="10">
+                        <VerticalStackLayout>
+                            <Label Text="{Binding Recurso.NombreRecurso}" FontAttributes="Bold"/>
+                            <Label Text="{Binding FechaRecursoUti, StringFormat='{0:d}'}"/>
+                            <Label Text="{Binding TotalRecursosUti, StringFormat='Total: {0:C}'}"/>
+                        </VerticalStackLayout>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/Views/RegistroRecursosPage.xaml.cs
+++ b/Views/RegistroRecursosPage.xaml.cs
@@ -1,0 +1,12 @@
+using DelCorp.ViewModels;
+
+namespace DelCorp.Views;
+
+public partial class RegistroRecursosPage : ContentPage
+{
+    public RegistroRecursosPage(RegistroRecursosViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}


### PR DESCRIPTION
## Summary
- add RegistroRecursoUti domain, supabase and local models
- create RegistroRecursoUtiMapper
- extend LocalDatabaseService and IDataService with registro recurso methods
- implement offline-first logic in OfflineFirstDataService
- create RegistroRecursos page and viewmodel
- wire navigation from project detail and subetapa pages
- register new page/viewmodel in MauiProgram and AppShell

## Testing
- `dotnet build -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68490028bb5c832b999d2a40e6d45d14