### PR TITLE
Add delete project feature from detail page

### DIFF
--- a/ViewModels/ProjectDetailViewModel.cs
+++ b/ViewModels/ProjectDetailViewModel.cs
@@ -130,4 +130,40 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
             );
         }
     }
+
+    [RelayCommand]
+    private async Task DeleteProject()
+    {
+        if (Project == null)
+            return;
+
+        bool confirmed = await Shell.Current.DisplayAlert(
+            "Confirmar Eliminación",
+            $"¿Estás seguro de que quieres eliminar el proyecto '{Project.NombreProyecto}'? Esta acción no se puede deshacer.",
+            "Sí, Eliminar",
+            "Cancelar");
+
+        if (!confirmed)
+            return;
+
+        try
+        {
+            bool success = await _dataService.DeleteProject(Project.Id);
+
+            if (success)
+            {
+                await Shell.Current.DisplayAlert("Éxito", "El proyecto ha sido eliminado.", "OK");
+                await Shell.Current.GoToAsync("..");
+            }
+            else
+            {
+                await Shell.Current.DisplayAlert("Error", "No se pudo eliminar el proyecto.", "OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error al eliminar el proyecto: {ex.Message}");
+            await Shell.Current.DisplayAlert("Error", "Ocurrió un error al eliminar el proyecto.", "OK");
+        }
+    }
 }

--- a/Views/ProjectDetailPage.xaml
+++ b/Views/ProjectDetailPage.xaml
@@ -84,7 +84,7 @@
                 </VerticalStackLayout>
             </Frame>
 
-            <CollectionView 
+            <CollectionView
                 ItemsSource="{Binding Presupuestos}"
                 HeightRequest="300"
                 SelectionMode="None">
@@ -126,6 +126,14 @@
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
+
+            <Button
+                Text="Eliminar Proyecto"
+                Command="{Binding DeleteProjectCommand}"
+                BackgroundColor="Red"
+                TextColor="White"
+                HorizontalOptions="FillAndExpand"
+                Margin="0,20,0,0" />
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/Views/ProjectPage.xaml.cs
+++ b/Views/ProjectPage.xaml.cs
@@ -4,9 +4,22 @@ namespace DelCorp.Views;
 
 public partial class ProjectPage : ContentPage
 {
-	public ProjectPage(ProjectViewModel projectViewModel)
-	{
-		InitializeComponent();
-        BindingContext = projectViewModel;
+    private readonly ProjectViewModel _viewModel;
+
+    public ProjectPage(ProjectViewModel projectViewModel)
+    {
+        InitializeComponent();
+        _viewModel = projectViewModel;
+        BindingContext = _viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+
+        if (_viewModel != null && _viewModel.RefreshProjectsCommand.CanExecute(null))
+        {
+            await _viewModel.RefreshProjectsCommand.ExecuteAsync(null);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enable deleting a project from its detail view
- show delete button in `ProjectDetailPage`
- refresh projects when returning to the project page

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849046a3e5c832b8fb1c686ec813160