### PR TITLE
Add resource usage tracking feature

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -14,6 +14,7 @@ namespace DelCorp
             RegisterForRoute<RegistrarEtapaPage>();
             RegisterForRoute<RegistrarSubEtapaPage>();
             RegisterForRoute<RegistrarRecursoUtiPage>();
+            RegisterForRoute<RegistrarAvancePage>();
         }
 
         protected void RegisterForRoute<T>()

--- a/DelCorp.csproj
+++ b/DelCorp.csproj
@@ -102,15 +102,18 @@
 	  <MauiXaml Update="Views\RegistrarPresupuestoPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\RegistrarRecursoUtiPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\RegistrarSubEtapaPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\UserProfilePage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+          <MauiXaml Update="Views\RegistrarRecursoUtiPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\RegistrarSubEtapaPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\RegistrarAvancePage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\UserProfilePage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
 	</ItemGroup>
 
 </Project>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -52,6 +52,7 @@ namespace DelCorp
             builder.Services.AddTransient<RegistrarEtapaViewModel>();
             builder.Services.AddTransient<RegistrarSubEtapaViewModel>();
             builder.Services.AddTransient<RegistrarRecursoUtiViewModel>();
+            builder.Services.AddTransient<RegistrarAvanceViewModel>();
 
             // Views
             builder.Services.AddSingleton<ProjectPage>();
@@ -65,6 +66,7 @@ namespace DelCorp
             builder.Services.AddTransient<RegistrarEtapaPage>();
             builder.Services.AddTransient<RegistrarSubEtapaPage>();
             builder.Services.AddTransient<RegistrarRecursoUtiPage>();
+            builder.Services.AddTransient<RegistrarAvancePage>();
 
             // Servicios
             builder.Services.AddSingleton<IDataService, OfflineFirstDataService>();

--- a/Models/Local/LocalRegistroRecursoUti.cs
+++ b/Models/Local/LocalRegistroRecursoUti.cs
@@ -1,0 +1,23 @@
+using SQLite;
+using System;
+
+namespace DelCorp.Models.Local
+{
+    [Table("LocalRegistroRecursoUti")]
+    public class LocalRegistroRecursoUti
+    {
+        [PrimaryKey, AutoIncrement]
+        public long LocalId { get; set; }
+
+        public long? ServerId { get; set; }
+        public bool IsSynced { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? FechaRecursoUti { get; set; }
+        public decimal? CantidadRecursosUti { get; set; }
+        public decimal? PrecioUniRecursosUti { get; set; }
+        public decimal? TotalRecursosUti { get; set; }
+        public long? IdRecurso { get; set; }
+        public long? IdSubEtapa { get; set; }
+        public long? IdUniMedida { get; set; }
+    }
+}

--- a/Models/RegistroRecursoUti.cs
+++ b/Models/RegistroRecursoUti.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace DelCorp.Models
+{
+    public class RegistroRecursoUti
+    {
+        public long IdRegistroRecursoUti { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? FechaRecursoUti { get; set; }
+        public decimal? CantidadRecursosUti { get; set; }
+        public decimal? PrecioUniRecursosUti { get; set; }
+        public decimal? TotalRecursosUti { get; set; }
+        public long? IdRecurso { get; set; }
+        public long? IdSubEtapa { get; set; }
+        public long? IdUniMedida { get; set; }
+
+        public Recurso Recurso { get; set; }
+        public UniMedRe UniMedRe { get; set; }
+    }
+}

--- a/Models/Supabase/SupabaseRegistroRecursoUti.cs
+++ b/Models/Supabase/SupabaseRegistroRecursoUti.cs
@@ -1,0 +1,37 @@
+using Postgrest.Attributes;
+using Postgrest.Models;
+using System;
+
+namespace DelCorp.Models.Supabase
+{
+    [Table("registro_recursos_uti")]
+    public class SupabaseRegistroRecursoUti : BaseModel
+    {
+        [PrimaryKey("id_registro_recurso_uti", false)]
+        public long IdRegistroRecursoUti { get; set; }
+
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [Column("fecha_recurso_uti")]
+        public DateTime? FechaRecursoUti { get; set; }
+
+        [Column("cantidad_recursos_uti")]
+        public decimal? CantidadRecursosUti { get; set; }
+
+        [Column("precio_uni_recursos_uti")]
+        public decimal? PrecioUniRecursosUti { get; set; }
+
+        [Column("total_recursos_uti")]
+        public decimal? TotalRecursosUti { get; set; }
+
+        [Column("id_recurso")]
+        public long? IdRecurso { get; set; }
+
+        [Column("id_sub_etapa")]
+        public long? IdSubEtapa { get; set; }
+
+        [Column("id_uni_medida")]
+        public long? IdUniMedida { get; set; }
+    }
+}

--- a/Services/IDataService.cs
+++ b/Services/IDataService.cs
@@ -57,5 +57,10 @@ namespace DelCorp.Services
         Task<IEnumerable<Actividad>> GetActividadesAsync(long? categoriaActividadId = null, string searchText = null);
         Task<Actividad> GetActividadByIdAsync(long actividadId);
         Task<Actividad> SaveActividadAsync(Actividad actividad); // Para crear nuevas actividades desde la app
+
+        // Registro Recursos Utilizados
+        Task<IEnumerable<RegistroRecursoUti>> GetRegistrosRecursosUtiBySubEtapaIdAsync(long subEtapaId);
+        Task<RegistroRecursoUti> SaveRegistroRecursoUtiAsync(RegistroRecursoUti registro);
+        Task DeleteRegistroRecursoUtiAsync(long registroId);
     }
 }

--- a/Services/LocalDatabaseService.cs
+++ b/Services/LocalDatabaseService.cs
@@ -24,6 +24,7 @@ public class LocalDatabaseService : IDisposable
         _database.CreateTableAsync<LocalRecursoUti>().Wait();
         _database.CreateTableAsync<LocalCategoriaActividad>().Wait();
         _database.CreateTableAsync<LocalActividad>().Wait();
+        _database.CreateTableAsync<LocalRegistroRecursoUti>().Wait();
     }
 
     public async Task ClearSessionAsync()
@@ -393,6 +394,29 @@ public class LocalDatabaseService : IDisposable
 
     public async Task<List<LocalRecursoUti>> GetUnsyncedRecursosUtiAsync() =>
         await _database.Table<LocalRecursoUti>().Where(r => !r.IsSynced).ToListAsync();
+
+    // RegistroRecursoUti helpers
+    public async Task<List<LocalRegistroRecursoUti>> GetRegistrosRecursosUtiBySubEtapaIdAsync(long subEtapaId)
+    {
+        return await _database.Table<LocalRegistroRecursoUti>().Where(r => r.IdSubEtapa == subEtapaId).ToListAsync();
+    }
+
+    public async Task SaveRegistroRecursoUtiAsync(LocalRegistroRecursoUti item)
+    {
+        if (item.LocalId != 0)
+        {
+            await _database.UpdateAsync(item);
+        }
+        else
+        {
+            await _database.InsertAsync(item);
+        }
+    }
+
+    public async Task DeleteRegistroRecursoUtiAsync(long localId)
+    {
+        await _database.Table<LocalRegistroRecursoUti>().DeleteAsync(r => r.LocalId == localId);
+    }
 
     // Para LocalCategoriaActividad
     public async Task<List<LocalCategoriaActividad>> GetCategoriasActividadAsync() =>

--- a/Services/Mapping/RegistroRecursoMapper.cs
+++ b/Services/Mapping/RegistroRecursoMapper.cs
@@ -1,0 +1,67 @@
+using DelCorp.Models;
+using DelCorp.Models.Local;
+using DelCorp.Models.Supabase;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DelCorp.Services.Mapping
+{
+    public static class RegistroRecursoMapper
+    {
+        public static RegistroRecursoUti ToDto(this SupabaseRegistroRecursoUti supabase) => supabase == null ? null : new RegistroRecursoUti
+        {
+            IdRegistroRecursoUti = supabase.IdRegistroRecursoUti,
+            CreatedAt = supabase.CreatedAt,
+            FechaRecursoUti = supabase.FechaRecursoUti,
+            CantidadRecursosUti = supabase.CantidadRecursosUti,
+            PrecioUniRecursosUti = supabase.PrecioUniRecursosUti,
+            TotalRecursosUti = supabase.TotalRecursosUti,
+            IdRecurso = supabase.IdRecurso,
+            IdSubEtapa = supabase.IdSubEtapa,
+            IdUniMedida = supabase.IdUniMedida
+        };
+
+        public static RegistroRecursoUti ToDto(this LocalRegistroRecursoUti local) => local == null ? null : new RegistroRecursoUti
+        {
+            IdRegistroRecursoUti = local.ServerId ?? 0,
+            CreatedAt = local.CreatedAt,
+            FechaRecursoUti = local.FechaRecursoUti,
+            CantidadRecursosUti = local.CantidadRecursosUti,
+            PrecioUniRecursosUti = local.PrecioUniRecursosUti,
+            TotalRecursosUti = local.TotalRecursosUti,
+            IdRecurso = local.IdRecurso,
+            IdSubEtapa = local.IdSubEtapa,
+            IdUniMedida = local.IdUniMedida
+        };
+
+        public static SupabaseRegistroRecursoUti ToSupabase(this RegistroRecursoUti dto) => dto == null ? null : new SupabaseRegistroRecursoUti
+        {
+            IdRegistroRecursoUti = dto.IdRegistroRecursoUti,
+            CreatedAt = dto.CreatedAt,
+            FechaRecursoUti = dto.FechaRecursoUti,
+            CantidadRecursosUti = dto.CantidadRecursosUti,
+            PrecioUniRecursosUti = dto.PrecioUniRecursosUti,
+            TotalRecursosUti = dto.TotalRecursosUti,
+            IdRecurso = dto.IdRecurso,
+            IdSubEtapa = dto.IdSubEtapa,
+            IdUniMedida = dto.IdUniMedida
+        };
+
+        public static LocalRegistroRecursoUti ToLocal(this RegistroRecursoUti dto, bool isSynced = false) => dto == null ? null : new LocalRegistroRecursoUti
+        {
+            ServerId = dto.IdRegistroRecursoUti,
+            CreatedAt = dto.CreatedAt,
+            FechaRecursoUti = dto.FechaRecursoUti,
+            CantidadRecursosUti = dto.CantidadRecursosUti,
+            PrecioUniRecursosUti = dto.PrecioUniRecursosUti,
+            TotalRecursosUti = dto.TotalRecursosUti,
+            IdRecurso = dto.IdRecurso,
+            IdSubEtapa = dto.IdSubEtapa,
+            IdUniMedida = dto.IdUniMedida,
+            IsSynced = isSynced
+        };
+
+        public static List<RegistroRecursoUti> ToDtoList(this IEnumerable<SupabaseRegistroRecursoUti> supabaseList) => supabaseList.Select(s => s.ToDto()).ToList();
+        public static List<RegistroRecursoUti> ToDtoList(this IEnumerable<LocalRegistroRecursoUti> localList) => localList.Select(l => l.ToDto()).ToList();
+    }
+}

--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -1646,5 +1646,88 @@ namespace DelCorp.Services
 
             return syncedDto ?? actividad; // Devolver el DTO sincronizado si está disponible, sino el original (que ahora podría tener ID)
         }
+
+        // --- RegistroRecursoUti methods ---
+        public async Task<IEnumerable<RegistroRecursoUti>> GetRegistrosRecursosUtiBySubEtapaIdAsync(long subEtapaId)
+        {
+            try
+            {
+                if (_connectivity.NetworkAccess == NetworkAccess.Internet)
+                {
+                    var response = await _supabaseClient.From<SupabaseRegistroRecursoUti>()
+                                                        .Filter("id_sub_etapa", Postgrest.Constants.Operator.Equals, subEtapaId.ToString())
+                                                        .Get();
+                    var dtos = response.Models.ToDtoList();
+
+                    var allRecursos = await GetRecursosAsync();
+                    var allUniMedRe = await GetUniMedReAsync();
+                    foreach (var dto in dtos)
+                    {
+                        dto.Recurso = allRecursos.FirstOrDefault(r => r.Id == dto.IdRecurso);
+                        dto.UniMedRe = allUniMedRe.FirstOrDefault(u => u.Id == dto.IdUniMedida);
+                    }
+                    return dtos;
+                }
+                else
+                {
+                    var localItems = await _localDatabase.GetRegistrosRecursosUtiBySubEtapaIdAsync(subEtapaId);
+                    return localItems.ToDtoList();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error obteniendo registros de recursos utilizados.");
+                return Enumerable.Empty<RegistroRecursoUti>();
+            }
+        }
+
+        public async Task<RegistroRecursoUti> SaveRegistroRecursoUtiAsync(RegistroRecursoUti registro)
+        {
+            var local = registro.ToLocal();
+            local.IsSynced = false;
+
+            if (registro.CantidadRecursosUti.HasValue && registro.PrecioUniRecursosUti.HasValue)
+            {
+                local.TotalRecursosUti = registro.CantidadRecursosUti.Value * registro.PrecioUniRecursosUti.Value;
+                registro.TotalRecursosUti = local.TotalRecursosUti;
+            }
+
+            await _localDatabase.SaveRegistroRecursoUtiAsync(local);
+
+            if (_connectivity.NetworkAccess == NetworkAccess.Internet)
+            {
+                try
+                {
+                    var supabaseModel = registro.ToSupabase();
+                    supabaseModel.IdRegistroRecursoUti = 0;
+
+                    var response = await _supabaseClient.From<SupabaseRegistroRecursoUti>().Insert(supabaseModel);
+                    var synced = response.Models.FirstOrDefault();
+
+                    if (synced != null)
+                    {
+                        local.ServerId = synced.IdRegistroRecursoUti;
+                        local.IsSynced = true;
+                        await _localDatabase.SaveRegistroRecursoUtiAsync(local);
+                        return synced.ToDto();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error guardando registro de recurso utilizado en Supabase.");
+                }
+            }
+            return registro;
+        }
+
+        public async Task DeleteRegistroRecursoUtiAsync(long registroId)
+        {
+            if (_connectivity.NetworkAccess == NetworkAccess.Internet)
+            {
+                await _supabaseClient.From<SupabaseRegistroRecursoUti>()
+                                         .Filter("id_registro_recurso_uti", Postgrest.Constants.Operator.Equals, registroId)
+                                         .Delete();
+            }
+        }
     }
 }

--- a/ViewModels/RegistrarAvanceViewModel.cs
+++ b/ViewModels/RegistrarAvanceViewModel.cs
@@ -1,0 +1,119 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DelCorp.Models;
+using DelCorp.Services;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DelCorp.ViewModels
+{
+    [QueryProperty(nameof(IdSubEtapa), "idSubEtapa")]
+    public partial class RegistrarAvanceViewModel : ObservableObject
+    {
+        private readonly IDataService _dataService;
+
+        [ObservableProperty]
+        private long _idSubEtapa;
+
+        [ObservableProperty]
+        private ObservableCollection<RecursoUti> _recursosPresupuestados;
+
+        [ObservableProperty]
+        private ObservableCollection<RegistroRecursoUti> _recursosYaRegistrados;
+
+        [ObservableProperty]
+        private ObservableCollection<Recurso> _recursosDisponibles;
+
+        [ObservableProperty]
+        private Recurso _recursoSeleccionado;
+
+        [ObservableProperty]
+        private DateTime _fechaDeUso = DateTime.Today;
+
+        [ObservableProperty]
+        private decimal? _cantidadUtilizada;
+
+        [ObservableProperty]
+        private decimal? _precioUnitario;
+
+        [ObservableProperty]
+        private bool _isBusy;
+
+        public RegistrarAvanceViewModel(IDataService dataService)
+        {
+            _dataService = dataService;
+            RecursosPresupuestados = new ObservableCollection<RecursoUti>();
+            RecursosYaRegistrados = new ObservableCollection<RegistroRecursoUti>();
+            RecursosDisponibles = new ObservableCollection<Recurso>();
+        }
+
+        partial void OnIdSubEtapaChanged(long value)
+        {
+            if (value > 0)
+            {
+                LoadDataCommand.ExecuteAsync(null);
+            }
+        }
+
+        [RelayCommand]
+        private async Task LoadDataAsync()
+        {
+            if (IsBusy) return;
+            IsBusy = true;
+
+            try
+            {
+                RecursosPresupuestados.Clear();
+                var presupuestados = await _dataService.GetRecursosUtiBySubEtapaIdAsync(IdSubEtapa);
+                foreach (var r in presupuestados) RecursosPresupuestados.Add(r);
+
+                RecursosYaRegistrados.Clear();
+                var registrados = await _dataService.GetRegistrosRecursosUtiBySubEtapaIdAsync(IdSubEtapa);
+                foreach (var r in registrados) RecursosYaRegistrados.Add(r);
+
+                RecursosDisponibles.Clear();
+                var disponibles = await _dataService.GetRecursosAsync();
+                foreach (var r in disponibles) RecursosDisponibles.Add(r);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        [RelayCommand]
+        private async Task GuardarAvanceAsync()
+        {
+            if (RecursoSeleccionado == null || !CantidadUtilizada.HasValue || !PrecioUnitario.HasValue)
+            {
+                await Shell.Current.DisplayAlert("Error", "Complete todos los campos.", "OK");
+                return;
+            }
+
+            var nuevoRegistro = new RegistroRecursoUti
+            {
+                IdSubEtapa = IdSubEtapa,
+                IdRecurso = RecursoSeleccionado.Id,
+                IdUniMedida = RecursosPresupuestados.FirstOrDefault(r => r.IdRecurso == RecursoSeleccionado.Id)?.IdUniMedRe,
+                FechaRecursoUti = FechaDeUso,
+                CantidadRecursosUti = CantidadUtilizada,
+                PrecioUniRecursosUti = PrecioUnitario
+            };
+
+            var guardado = await _dataService.SaveRegistroRecursoUtiAsync(nuevoRegistro);
+
+            if (guardado != null)
+            {
+                RecursosYaRegistrados.Add(guardado);
+                RecursoSeleccionado = null;
+                CantidadUtilizada = null;
+                PrecioUnitario = null;
+            }
+            else
+            {
+                await Shell.Current.DisplayAlert("Error", "No se pudo guardar el registro.", "OK");
+            }
+        }
+    }
+}

--- a/ViewModels/RegistrarSubEtapaViewModel.cs
+++ b/ViewModels/RegistrarSubEtapaViewModel.cs
@@ -419,6 +419,13 @@ public partial class RegistrarSubEtapaViewModel : ObservableObject, IQueryAttrib
         }
     }
 
+    [RelayCommand]
+    private async Task NavigateToRegistrarAvanceAsync(SubEtapa subEtapa)
+    {
+        if (subEtapa == null || subEtapa.Id == 0) return;
+        await Shell.Current.GoToAsync($"RegistrarAvancePage?idSubEtapa={subEtapa.Id}");
+    }
+
     // --- MÉTODOS Y COMANDOS PARA REORDENAMIENTO OPTIMIZADO DE SUBETAPAS ---
     private void LocalRenumberSubEtapas()
     {

--- a/Views/RegistrarAvancePage.xaml
+++ b/Views/RegistrarAvancePage.xaml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="DelCorp.Views.RegistrarAvancePage"
+             xmlns:viewmodels="clr-namespace:DelCorp.ViewModels"
+             xmlns:models="clr-namespace:DelCorp.Models"
+             x:DataType="viewmodels:RegistrarAvanceViewModel"
+             Title="Registrar Avance de Recursos">
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="10">
+
+            <Label Text="Recursos Presupuestados" FontAttributes="Bold" FontSize="Medium"/>
+            <CollectionView ItemsSource="{Binding RecursosPresupuestados}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:RecursoUti">
+                        <Frame Padding="10" Margin="0,5" BorderColor="LightGray">
+                            <HorizontalStackLayout Spacing="10">
+                                <Label Text="{Binding Recurso.NombreRecurso}" FontAttributes="Bold" VerticalOptions="Center"/>
+                                <Label Text="{Binding CantidadRecursosUti, StringFormat='Cant: {0}'}" VerticalOptions="Center"/>
+                                <Label Text="{Binding UniMedRe.AbreviaturaUniMedRe}" VerticalOptions="Center"/>
+                            </HorizontalStackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+            <BoxView HeightRequest="1" Color="Gray" Margin="0,15"/>
+
+            <Label Text="Registrar Nuevo Uso de Recurso" FontAttributes="Bold" FontSize="Medium"/>
+
+            <Label Text="Recurso:"/>
+            <Picker ItemsSource="{Binding RecursosDisponibles}"
+                    ItemDisplayBinding="{Binding NombreRecurso}"
+                    SelectedItem="{Binding RecursoSeleccionado}"
+                    Title="Seleccione un recurso"/>
+
+            <Label Text="Fecha de Uso:"/>
+            <DatePicker Date="{Binding FechaDeUso}"/>
+            
+            <Label Text="Cantidad Utilizada:"/>
+            <Entry Keyboard="Numeric" Text="{Binding CantidadUtilizada}"/>
+
+            <Label Text="Precio Unitario Real:"/>
+            <Entry Keyboard="Numeric" Text="{Binding PrecioUnitario}"/>
+
+            <Button Text="Guardar Avance" Command="{Binding GuardarAvanceCommand}" Margin="0,20"/>
+
+            <BoxView HeightRequest="1" Color="Gray" Margin="0,15"/>
+            
+            <Label Text="Recursos Ya Registrados (Utilizados)" FontAttributes="Bold" FontSize="Medium"/>
+            <CollectionView ItemsSource="{Binding RecursosYaRegistrados}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:RegistroRecursoUti">
+                        <Frame Padding="10" Margin="0,5" BorderColor="LightBlue">
+                            <StackLayout>
+                                <Label Text="{Binding Recurso.NombreRecurso}" FontAttributes="Bold"/>
+                                <HorizontalStackLayout Spacing="10">
+                                    <Label Text="{Binding FechaRecursoUti, StringFormat='{0:dd/MM/yyyy}'}"/>
+                                    <Label Text="{Binding CantidadRecursosUti, StringFormat='Cant: {0}'}"/>
+                                    <Label Text="{Binding TotalRecursosUti, StringFormat='Total: C${0:N2}'}"/>
+                                </HorizontalStackLayout>
+                            </StackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Views/RegistrarAvancePage.xaml.cs
+++ b/Views/RegistrarAvancePage.xaml.cs
@@ -1,0 +1,12 @@
+using DelCorp.ViewModels;
+
+namespace DelCorp.Views;
+
+public partial class RegistrarAvancePage : ContentPage
+{
+    public RegistrarAvancePage(RegistrarAvanceViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/Views/RegistrarSubEtapaPage.xaml
+++ b/Views/RegistrarSubEtapaPage.xaml
@@ -78,6 +78,9 @@
                                 <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" Text="Añadir/Ver Recursos"
                                         Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:RegistrarSubEtapaViewModel}}, Path=NavigateToRegistrarRecursosCommand}"
                                         CommandParameter="{Binding .}" Margin="0,5,0,0"/>
+                                <Button Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3" Text="Registrar Avance" BackgroundColor="Orange"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:RegistrarSubEtapaViewModel}}, Path=NavigateToRegistrarAvanceCommand}"
+                                        CommandParameter="{Binding .}" Margin="0,5,0,0"/>
                             </Grid>
                         </Frame>
                     </DataTemplate>


### PR DESCRIPTION
## Summary
- add models for `RegistroRecursoUti` with Supabase/local versions
- create mapper for `RegistroRecursoUti`
- update local DB service to handle new table
- extend `IDataService` and `OfflineFirstDataService` with methods for resource usage
- implement `RegistrarAvanceViewModel` and related page
- add navigation and DI wires
- update SubEtapa page and viewmodel with "Registrar Avance" button

## Testing
- `dotnet build -v minimal` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490b2a698c832ba1c55d321d339e8c