### PR TITLE
Implement budget total recalculation

### DIFF
--- a/Services/IDataService.cs
+++ b/Services/IDataService.cs
@@ -62,5 +62,8 @@ namespace DelCorp.Services
         Task<IEnumerable<RegistroRecursoUti>> GetRegistrosRecursosUtiBySubEtapaIdAsync(long subEtapaId);
         Task<RegistroRecursoUti> SaveRegistroRecursoUtiAsync(RegistroRecursoUti registro);
         Task DeleteRegistroRecursoUtiAsync(long registroId);
+
+        // Obtiene la suma total de los recursos utilizados para un presupuesto
+        Task<decimal> GetTotalEjecutadoForPresupuestoAsync(long presupuestoId);
     }
 }

--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -5,6 +5,8 @@ using DelCorp.Services.Mapping;
 using Supabase;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
 using Postgrest.Responses;
 using Supabase.Interfaces;
 
@@ -1728,6 +1730,42 @@ namespace DelCorp.Services
                                          .Filter("id_registro_recurso_uti", Postgrest.Constants.Operator.Equals, registroId)
                                          .Delete();
             }
+        }
+
+        public async Task<decimal> GetTotalEjecutadoForPresupuestoAsync(long presupuestoId)
+        {
+            decimal totalGeneral = 0;
+            try
+            {
+                var etapas = await _localDatabase.GetEtapasByPresupuestoIdAsync(presupuestoId);
+                var idEtapas = etapas.Select(e => e.Id).ToList();
+
+                if (!idEtapas.Any()) return 0;
+
+                var subEtapas = new List<LocalSubEtapa>();
+                foreach (var idEtapa in idEtapas)
+                {
+                    var subs = await _localDatabase.GetSubEtapasByEtapaIdAsync(idEtapa);
+                    subEtapas.AddRange(subs);
+                }
+                var idSubEtapas = subEtapas.Select(s => s.Id).ToList();
+
+                if (!idSubEtapas.Any()) return 0;
+
+                var registros = new List<LocalRegistroRecursoUti>();
+                foreach (var idSubEtapa in idSubEtapas)
+                {
+                    var regs = await _localDatabase.GetRegistrosRecursosUtiBySubEtapaIdAsync(idSubEtapa);
+                    registros.AddRange(regs);
+                }
+
+                totalGeneral = registros.Sum(r => r.TotalRecursosUti ?? 0);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error calculando el total ejecutado para el presupuesto {PresupuestoId}", presupuestoId);
+            }
+            return totalGeneral;
         }
     }
 }

--- a/ViewModels/RegistrarAvanceViewModel.cs
+++ b/ViewModels/RegistrarAvanceViewModel.cs
@@ -9,36 +9,22 @@ using System.Threading.Tasks;
 namespace DelCorp.ViewModels
 {
     [QueryProperty(nameof(IdSubEtapa), "idSubEtapa")]
+    [QueryProperty(nameof(IdPresupuesto), "idPresupuesto")]
     public partial class RegistrarAvanceViewModel : ObservableObject
     {
         private readonly IDataService _dataService;
 
-        [ObservableProperty]
-        private long _idSubEtapa;
+        [ObservableProperty] private long _idSubEtapa;
+        [ObservableProperty] private long _idPresupuesto;
 
-        [ObservableProperty]
-        private ObservableCollection<RecursoUti> _recursosPresupuestados;
-
-        [ObservableProperty]
-        private ObservableCollection<RegistroRecursoUti> _recursosYaRegistrados;
-
-        [ObservableProperty]
-        private ObservableCollection<Recurso> _recursosDisponibles;
-
-        [ObservableProperty]
-        private Recurso _recursoSeleccionado;
-
-        [ObservableProperty]
-        private DateTime _fechaDeUso = DateTime.Today;
-
-        [ObservableProperty]
-        private decimal? _cantidadUtilizada;
-
-        [ObservableProperty]
-        private decimal? _precioUnitario;
-
-        [ObservableProperty]
-        private bool _isBusy;
+        [ObservableProperty] private ObservableCollection<RecursoUti> _recursosPresupuestados;
+        [ObservableProperty] private ObservableCollection<RegistroRecursoUti> _recursosYaRegistrados;
+        [ObservableProperty] private ObservableCollection<Recurso> _recursosDisponibles;
+        [ObservableProperty] private Recurso _recursoSeleccionado;
+        [ObservableProperty] private DateTime _fechaDeUso = DateTime.Today;
+        [ObservableProperty] private decimal? _cantidadUtilizada;
+        [ObservableProperty] private decimal? _precioUnitario;
+        [ObservableProperty] private bool _isBusy;
 
         public RegistrarAvanceViewModel(IDataService dataService)
         {
@@ -50,10 +36,7 @@ namespace DelCorp.ViewModels
 
         partial void OnIdSubEtapaChanged(long value)
         {
-            if (value > 0)
-            {
-                LoadDataCommand.ExecuteAsync(null);
-            }
+            if (value > 0) LoadDataCommand.ExecuteAsync(null);
         }
 
         [RelayCommand]
@@ -61,7 +44,6 @@ namespace DelCorp.ViewModels
         {
             if (IsBusy) return;
             IsBusy = true;
-
             try
             {
                 RecursosPresupuestados.Clear();
@@ -105,15 +87,53 @@ namespace DelCorp.ViewModels
 
             if (guardado != null)
             {
+                guardado.Recurso = RecursoSeleccionado;
                 RecursosYaRegistrados.Add(guardado);
                 RecursoSeleccionado = null;
                 CantidadUtilizada = null;
                 PrecioUnitario = null;
+
+                await UpdatePresupuestoTotalEjecutadoAsync();
             }
             else
             {
                 await Shell.Current.DisplayAlert("Error", "No se pudo guardar el registro.", "OK");
             }
         }
+
+        [RelayCommand]
+        private async Task DeleteAvanceAsync(RegistroRecursoUti registro)
+        {
+            if (registro == null) return;
+
+            bool confirm = await Shell.Current.DisplayAlert("Confirmar", "¿Eliminar este registro de avance?", "Sí", "No");
+            if (!confirm) return;
+
+            await _dataService.DeleteRegistroRecursoUtiAsync(registro.IdRegistroRecursoUti);
+            RecursosYaRegistrados.Remove(registro);
+
+            await UpdatePresupuestoTotalEjecutadoAsync();
+        }
+
+        private async Task UpdatePresupuestoTotalEjecutadoAsync()
+        {
+            if (IdPresupuesto == 0) return;
+
+            try
+            {
+                var presupuesto = await _dataService.GetPresupuestoByIdAsync(IdPresupuesto);
+                if (presupuesto != null)
+                {
+                    var totalEjecutado = await _dataService.GetTotalEjecutadoForPresupuestoAsync(IdPresupuesto);
+                    presupuesto.MontoEjePresupuesto = totalEjecutado;
+                    await _dataService.SavePresupuesto(presupuesto);
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error actualizando el monto ejecutado del presupuesto: {ex.Message}");
+            }
+        }
     }
 }
+

--- a/ViewModels/RegistrarEtapaViewModel.cs
+++ b/ViewModels/RegistrarEtapaViewModel.cs
@@ -302,7 +302,7 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
             // Podríamos resetear HasPendingOrderChanges aquí si no se guardan.
             // HasPendingOrderChanges = false; // Si continúan sin guardar
         }
-        await Shell.Current.GoToAsync($"RegistrarSubEtapaPage?idEtapa={etapa.Id}");
+        await Shell.Current.GoToAsync($"{nameof(RegistrarSubEtapaPage)}?idEtapa={etapa.Id}&idPresupuesto={IdPresupuesto}");
     }
 
     partial void OnSelectedActividadChanged(Actividad oldValue, Actividad newValue)

--- a/ViewModels/RegistrarSubEtapaViewModel.cs
+++ b/ViewModels/RegistrarSubEtapaViewModel.cs
@@ -16,6 +16,9 @@ public partial class RegistrarSubEtapaViewModel : ObservableObject, IQueryAttrib
     private readonly IDataService _dataService;
 
     [ObservableProperty] private long _idEtapa;
+
+    // Id del presupuesto al que pertenece la etapa actual
+    [ObservableProperty] private long _idPresupuesto;
     [ObservableProperty] private decimal? _cantidadSubEtapa;
     [ObservableProperty] private decimal? _precioUniSubEtapa;
     [ObservableProperty] private decimal? _totalSubEstapa;
@@ -111,6 +114,12 @@ public partial class RegistrarSubEtapaViewModel : ObservableObject, IQueryAttrib
 
     public async void ApplyQueryAttributes(IDictionary<string, object> query)
     {
+        // Leer IdPresupuesto si viene en la navegación
+        if (query.TryGetValue("idPresupuesto", out var idPresupuestoObj) && long.TryParse(idPresupuestoObj.ToString(), out var idPresupuestoVal))
+        {
+            IdPresupuesto = idPresupuestoVal;
+        }
+
         if (query.TryGetValue("idEtapa", out var idObj) && long.TryParse(idObj.ToString(), out var etapaIdVal))
         {
             bool needsFullLoadOrDifferentEtapa = IdEtapa != etapaIdVal;
@@ -423,7 +432,7 @@ public partial class RegistrarSubEtapaViewModel : ObservableObject, IQueryAttrib
     private async Task NavigateToRegistrarAvanceAsync(SubEtapa subEtapa)
     {
         if (subEtapa == null || subEtapa.Id == 0) return;
-        await Shell.Current.GoToAsync($"RegistrarAvancePage?idSubEtapa={subEtapa.Id}");
+        await Shell.Current.GoToAsync($"{nameof(RegistrarAvancePage)}?idSubEtapa={subEtapa.Id}&idPresupuesto={IdPresupuesto}");
     }
 
     // --- MÉTODOS Y COMANDOS PARA REORDENAMIENTO OPTIMIZADO DE SUBETAPAS ---

--- a/Views/RegistrarAvancePage.xaml
+++ b/Views/RegistrarAvancePage.xaml
@@ -52,14 +52,25 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="models:RegistroRecursoUti">
                         <Frame Padding="10" Margin="0,5" BorderColor="LightBlue">
-                            <StackLayout>
-                                <Label Text="{Binding Recurso.NombreRecurso}" FontAttributes="Bold"/>
-                                <HorizontalStackLayout Spacing="10">
-                                    <Label Text="{Binding FechaRecursoUti, StringFormat='{0:dd/MM/yyyy}'}"/>
-                                    <Label Text="{Binding CantidadRecursosUti, StringFormat='Cant: {0}'}"/>
-                                    <Label Text="{Binding TotalRecursosUti, StringFormat='Total: C${0:N2}'}"/>
-                                </HorizontalStackLayout>
-                            </StackLayout>
+                            <Grid ColumnDefinitions="*,Auto">
+                                <StackLayout Grid.Column="0">
+                                    <Label Text="{Binding Recurso.NombreRecurso}" FontAttributes="Bold"/>
+                                    <HorizontalStackLayout Spacing="10">
+                                        <Label Text="{Binding FechaRecursoUti, StringFormat='{0:dd/MM/yyyy}'}"/>
+                                        <Label Text="{Binding CantidadRecursosUti, StringFormat='Cant: {0}'}"/>
+                                        <Label Text="{Binding TotalRecursosUti, StringFormat='Total: C${0:N2}'}"/>
+                                    </HorizontalStackLayout>
+                                </StackLayout>
+                                <Button Grid.Column="1"
+                                        Text="X"
+                                        TextColor="White"
+                                        BackgroundColor="Red"
+                                        WidthRequest="40"
+                                        HeightRequest="40"
+                                        CornerRadius="20"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:RegistrarAvanceViewModel}}, Path=DeleteAvanceCommand}"
+                                        CommandParameter="{Binding .}"/>
+                            </Grid>
                         </Frame>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>


### PR DESCRIPTION
## Summary
- pass budget id in navigation from stages to sub-stages
- propagate budget id when opening advances page
- recalc total executed budget whenever advances change
- expose new service method to sum executed resources
- implement total calculation in OfflineFirstDataService
- add delete option for recorded advances

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684911cbcc20832b8a2fd0c42ea11ad9