### PR TITLE
Implement edit features for projects and budgets

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -10,7 +10,9 @@ namespace DelCorp
 
             RegisterForRoute<AddProjectPage>();
             RegisterForRoute<ProjectDetailPage>();
+            RegisterForRoute<EditProjectPage>();
             RegisterForRoute<RegistrarPresupuestoPage>();
+            RegisterForRoute<EditPresupuestoPage>();
             RegisterForRoute<RegistrarEtapaPage>();
             RegisterForRoute<RegistrarSubEtapaPage>();
             RegisterForRoute<RegistrarRecursoUtiPage>();

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -43,6 +43,7 @@ namespace DelCorp
             // ViewModels
             builder.Services.AddSingleton<ProjectViewModel>();
             builder.Services.AddTransient<AddProjectViewModel>();
+            builder.Services.AddTransient<EditProjectViewModel>();
             builder.Services.AddTransient<ProjectDetailViewModel>();
             builder.Services.AddTransient<LoginViewModel>();
             builder.Services.AddTransient<RegisterViewModel>();
@@ -53,11 +54,13 @@ namespace DelCorp
             builder.Services.AddTransient<RegistrarSubEtapaViewModel>();
             builder.Services.AddTransient<RegistrarRecursoUtiViewModel>();
             builder.Services.AddTransient<RegistrarAvanceViewModel>();
+            builder.Services.AddTransient<EditPresupuestoViewModel>();
 
             // Views
             builder.Services.AddSingleton<ProjectPage>();
             builder.Services.AddTransient<AddProjectPage>();
             builder.Services.AddTransient<ProjectDetailPage>();
+            builder.Services.AddTransient<EditProjectPage>();
             builder.Services.AddTransient<LoginPage>();
             builder.Services.AddTransient<RegisterPage>();
             builder.Services.AddTransient<UserProfilePage>();
@@ -67,6 +70,7 @@ namespace DelCorp
             builder.Services.AddTransient<RegistrarSubEtapaPage>();
             builder.Services.AddTransient<RegistrarRecursoUtiPage>();
             builder.Services.AddTransient<RegistrarAvancePage>();
+            builder.Services.AddTransient<EditPresupuestoPage>();
 
             // Servicios
             builder.Services.AddSingleton<IDataService, OfflineFirstDataService>();

--- a/ViewModels/EditPresupuestoViewModel.cs
+++ b/ViewModels/EditPresupuestoViewModel.cs
@@ -1,0 +1,65 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DelCorp.Models;
+using DelCorp.Services;
+
+namespace DelCorp.ViewModels
+{
+    [QueryProperty(nameof(PresupuestoId), "id")]
+    public partial class EditPresupuestoViewModel : ObservableObject
+    {
+        private readonly IDataService _dataService;
+
+        [ObservableProperty]
+        private Presupuesto _presupuestoToEdit;
+
+        [ObservableProperty]
+        private long _presupuestoId;
+
+        [ObservableProperty]
+        private bool _isLoading;
+
+        public EditPresupuestoViewModel(IDataService dataService)
+        {
+            _dataService = dataService;
+        }
+
+        async partial void OnPresupuestoIdChanged(long value)
+        {
+            if (value > 0)
+            {
+                IsLoading = true;
+                PresupuestoToEdit = await _dataService.GetPresupuestoByIdAsync(value);
+                IsLoading = false;
+            }
+        }
+
+        [RelayCommand]
+        private async Task UpdatePresupuesto()
+        {
+            if (string.IsNullOrWhiteSpace(PresupuestoToEdit.NombrePresupuesto))
+            {
+                await Shell.Current.DisplayAlert("Error", "El nombre del presupuesto es requerido.", "OK");
+                return;
+            }
+
+            IsLoading = true;
+            try
+            {
+                var result = await _dataService.SavePresupuesto(PresupuestoToEdit);
+                if (result != null)
+                {
+                    await Shell.Current.GoToAsync("..");
+                }
+                else
+                {
+                    await Shell.Current.DisplayAlert("Error", "No se pudo actualizar el presupuesto.", "OK");
+                }
+            }
+            finally
+            {
+                IsLoading = false;
+            }
+        }
+    }
+}

--- a/ViewModels/EditProjectViewModel.cs
+++ b/ViewModels/EditProjectViewModel.cs
@@ -1,0 +1,88 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DelCorp.Models;
+using DelCorp.Services;
+
+namespace DelCorp.ViewModels
+{
+    [QueryProperty(nameof(ProjectId), "id")]
+    public partial class EditProjectViewModel : ObservableObject
+    {
+        private readonly IDataService _dataService;
+
+        [ObservableProperty]
+        private Project _projectToEdit;
+
+        [ObservableProperty]
+        private int _projectId;
+
+        [ObservableProperty]
+        private bool _isLoading;
+
+        [ObservableProperty]
+        private Dictionary<string, string> _validationErrors = new();
+
+        public EditProjectViewModel(IDataService dataService)
+        {
+            _dataService = dataService;
+        }
+
+        async partial void OnProjectIdChanged(int value)
+        {
+            if (value > 0)
+            {
+                await LoadProject(value);
+            }
+        }
+
+        private async Task LoadProject(int projectId)
+        {
+            IsLoading = true;
+            ProjectToEdit = await _dataService.GetProject(projectId);
+            IsLoading = false;
+        }
+
+        private bool ValidateProject()
+        {
+            ValidationErrors.Clear();
+            if (string.IsNullOrWhiteSpace(ProjectToEdit.NombreProyecto))
+                ValidationErrors[nameof(ProjectToEdit.NombreProyecto)] = "El nombre del proyecto es requerido";
+
+            return ValidationErrors.Count == 0;
+        }
+
+        [RelayCommand]
+        private async Task UpdateProject()
+        {
+            if (!ValidateProject())
+            {
+                var errorMessage = string.Join("\n", ValidationErrors.Values);
+                await Shell.Current.DisplayAlert("Errores de Validación", errorMessage, "OK");
+                return;
+            }
+
+            IsLoading = true;
+            try
+            {
+                bool result = await _dataService.SaveProject(ProjectToEdit);
+
+                if (result)
+                {
+                    await Shell.Current.GoToAsync("..");
+                }
+                else
+                {
+                    await Shell.Current.DisplayAlert("Error", "No se pudo actualizar el proyecto", "OK");
+                }
+            }
+            catch (Exception ex)
+            {
+                await Shell.Current.DisplayAlert("Error", $"Ocurrió un error: {ex.Message}", "OK");
+            }
+            finally
+            {
+                IsLoading = false;
+            }
+        }
+    }
+}

--- a/ViewModels/ProjectDetailViewModel.cs
+++ b/ViewModels/ProjectDetailViewModel.cs
@@ -18,6 +18,9 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
 
     [ObservableProperty]
     private Project _project;
+    [ObservableProperty]
+    private int _projectId;
+
 
     [ObservableProperty]
     private ObservableCollection<Presupuesto> _presupuestos;
@@ -41,6 +44,7 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
     {
         // Obtener el proyecto por ID con el metodo de _dataService
         Project = await _dataService.GetProject(id);
+        ProjectId = id;
 
         // Si el proyecto no se encuentra navegar hacia atrás y mostrar un mensaje de error
         if (Project == null)
@@ -165,5 +169,12 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
             Debug.WriteLine($"Error al eliminar el proyecto: {ex.Message}");
             await Shell.Current.DisplayAlert("Error", "Ocurrió un error al eliminar el proyecto.", "OK");
         }
+    }
+
+    [RelayCommand]
+    private async Task EditProject()
+    {
+        if (ProjectId == 0) return;
+        await Shell.Current.GoToAsync($"{nameof(EditProjectPage)}?id={ProjectId}");
     }
 }

--- a/ViewModels/RegistrarEtapaViewModel.cs
+++ b/ViewModels/RegistrarEtapaViewModel.cs
@@ -582,4 +582,11 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
             SetIsBusy(false);
         }
     }
+
+    [RelayCommand]
+    private async Task EditPresupuesto()
+    {
+        if (IdPresupuesto == 0) return;
+        await Shell.Current.GoToAsync($"{nameof(EditPresupuestoPage)}?id={IdPresupuesto}");
+    }
 }

--- a/Views/EditPresupuestoPage.xaml
+++ b/Views/EditPresupuestoPage.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="DelCorp.Views.EditPresupuestoPage"
+             xmlns:viewmodel="clr-namespace:DelCorp.ViewModels"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             x:DataType="viewmodel:EditPresupuestoViewModel"
+             Title="Editar Presupuesto">
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="15" BindableLayout.ItemsSource="{Binding PresupuestoToEdit}">
+            <Label Text="Nombre del Presupuesto" />
+            <Entry Text="{Binding NombrePresupuesto}" />
+            
+            <Label Text="Fecha de Inicio" />
+            <DatePicker Date="{Binding FechaInicioPresupuesto, TargetNullValue={x:Static sys:DateTime.Now}}" />
+
+            <Label Text="Fecha de Fin" />
+            <DatePicker Date="{Binding FechaFinPresupuesto, TargetNullValue={x:Static sys:DateTime.Now}}" />
+
+            <Button Text="Actualizar Presupuesto" Command="{Binding UpdatePresupuestoCommand}" IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}"/>
+            <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Views/EditPresupuestoPage.xaml.cs
+++ b/Views/EditPresupuestoPage.xaml.cs
@@ -1,0 +1,12 @@
+using DelCorp.ViewModels;
+
+namespace DelCorp.Views;
+
+public partial class EditPresupuestoPage : ContentPage
+{
+    public EditPresupuestoPage(EditPresupuestoViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/Views/EditProjectPage.xaml
+++ b/Views/EditProjectPage.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="DelCorp.Views.EditProjectPage"
+             xmlns:viewmodel="clr-namespace:DelCorp.ViewModels"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             x:DataType="viewmodel:EditProjectViewModel"
+             Title="Editar Proyecto">
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="15">
+            <Label Text="Nombre del Proyecto" />
+            <Entry Text="{Binding ProjectToEdit.NombreProyecto}" />
+
+            <Label Text="Descripción" />
+            <Editor Text="{Binding ProjectToEdit.DescripcionProyecto}" HeightRequest="100" />
+
+            <Label Text="Dirección" />
+            <Entry Text="{Binding ProjectToEdit.DireccionProyecto}" />
+            
+            <Label Text="Fecha de Inicio" />
+            <DatePicker Date="{Binding ProjectToEdit.FechaInicioProyecto, TargetNullValue={x:Static sys:DateTime.Now}}" />
+
+            <Label Text="Fecha de Fin" />
+            <DatePicker Date="{Binding ProjectToEdit.FechaFinProyecto, TargetNullValue={x:Static sys:DateTime.Now}}" />
+
+            <Button Text="Actualizar Proyecto" Command="{Binding UpdateProjectCommand}" IsEnabled="{Binding IsLoading, Converter={StaticResource InverseBoolConverter}}" />
+            <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Views/EditProjectPage.xaml.cs
+++ b/Views/EditProjectPage.xaml.cs
@@ -1,0 +1,12 @@
+using DelCorp.ViewModels;
+
+namespace DelCorp.Views;
+
+public partial class EditProjectPage : ContentPage
+{
+    public EditProjectPage(EditProjectViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/Views/ProjectDetailPage.xaml
+++ b/Views/ProjectDetailPage.xaml
@@ -127,6 +127,7 @@
                 </CollectionView.ItemTemplate>
             </CollectionView>
 
+            <Button Text="Editar Proyecto" Command="{Binding EditProjectCommand}" />
             <Button
                 Text="Eliminar Proyecto"
                 Command="{Binding DeleteProjectCommand}"

--- a/Views/RegistrarEtapaPage.xaml
+++ b/Views/RegistrarEtapaPage.xaml
@@ -45,6 +45,7 @@
                     IsEnabled="{Binding IsNotBusy}" />
 
             <ActivityIndicator IsRunning="{Binding IsBusy}" IsVisible="{Binding IsBusy}" />
+            <Button Text="Editar Detalles del Presupuesto" Command="{Binding EditPresupuestoCommand}" />
 
 
             <Label Text="Etapas Registradas" FontAttributes="Bold" FontSize="Medium" Margin="0,20,0,0"/>


### PR DESCRIPTION
## Summary
- add `EditProjectViewModel` and edit page to update projects
- enable navigation to edit project
- add `EditPresupuestoViewModel` and edit page to update budgets
- allow editing a presupuesto from `RegistrarEtapa` page
- register new pages and view models in DI and routes

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(failed: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_684994f110d4832b97acdd5967483a36