### PR TITLE
Fix budget id mapping

### DIFF
--- a/Services/Mapping/ModelMapper.cs
+++ b/Services/Mapping/ModelMapper.cs
@@ -139,7 +139,9 @@ namespace DelCorp.Services.Mapping
         {
             return new Presupuesto
             {
-                Id = localPresupuesto.ServerId ?? localPresupuesto.Id,
+                Id = (localPresupuesto.ServerId.HasValue && localPresupuesto.ServerId.Value > 0)
+                    ? localPresupuesto.ServerId.Value
+                    : localPresupuesto.Id,
                 CreatedAt = localPresupuesto.CreatedAt,
                 NombrePresupuesto = localPresupuesto.NombrePresupuesto,
                 TotalPresupuesto = localPresupuesto.TotalPresupuesto,
@@ -157,7 +159,7 @@ namespace DelCorp.Services.Mapping
         {
             return new LocalPresupuesto
             {
-                ServerId = presupuesto.Id,
+                ServerId = presupuesto.Id > 0 ? (long?)presupuesto.Id : null,
                 CreatedAt = presupuesto.CreatedAt,
                 NombrePresupuesto = presupuesto.NombrePresupuesto,
                 TotalPresupuesto = presupuesto.TotalPresupuesto,


### PR DESCRIPTION
## Summary
- ensure Presupuesto gets real ID when saved locally by not using zero as ServerId
- treat zero ServerId as unset when converting back to DTO

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499ddc5080832bbb3163fe6c5c44c9