### PR TITLE
Fix duplicated budgets by using random ID

### DIFF
--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -585,6 +585,8 @@ namespace DelCorp.Services
             {
                 if (presupuesto.Id == 0)
                 {
+                    // Asignar un Id temporal para evitar registros con valor 0
+                    presupuesto.Id = GenerarIdAleatorio();
                     presupuesto.CreatedAt = DateTime.Now;
                 }
 

--- a/ViewModels/RegistrarPresupuestoViewModel.cs
+++ b/ViewModels/RegistrarPresupuestoViewModel.cs
@@ -145,9 +145,10 @@ public partial class RegistrarPresupuestoViewModel : ObservableObject
         IsBusy = true;
         try
         {
-            // Crear el objeto Presupuesto sin asignar un Id
+            // Crear el objeto Presupuesto asignando un Id temporal aleatorio
             var presupuesto = new Presupuesto
             {
+                Id = OfflineFirstDataService.GenerarIdAleatorio(),
                 NombrePresupuesto = NombrePresupuesto,
                 FechaInicioPresupuesto = FechaInicioPresupuesto,
                 FechaFinPresupuesto = FechaFinPresupuesto,


### PR DESCRIPTION
## Summary
- assign a random ID when registering a new budget in the view model
- ensure `SavePresupuesto` assigns a random ID if the incoming ID is zero

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499f8ece5c832bac087e95d91c21ce