### PR TITLE
Show executed budget totals

### DIFF
--- a/Converters/BudgetProgressConverter.cs
+++ b/Converters/BudgetProgressConverter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+using DelCorp.Models;
+
+namespace DelCorp.Converters
+{
+    public class BudgetProgressConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Presupuesto presupuesto)
+            {
+                var total = presupuesto.TotalPresupuesto ?? 0m;
+                var spent = presupuesto.MontoEjePresupuesto ?? 0m;
+
+                if (total > 0)
+                {
+                    return (double)(spent / total);
+                }
+            }
+            return 0d;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Converters/GastoToColorConverter.cs
+++ b/Converters/GastoToColorConverter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+using DelCorp.Models;
+
+namespace DelCorp.Converters
+{
+    public class GastoToColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Presupuesto p)
+            {
+                var total = p.TotalPresupuesto ?? 0m;
+                var spent = p.MontoEjePresupuesto ?? 0m;
+                return spent > total ? Colors.Red : Colors.Black;
+            }
+            if (value is decimal spentValue && parameter is decimal totalValue)
+            {
+                return spentValue > totalValue ? Colors.Red : Colors.Black;
+            }
+            return Colors.Black;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Converters/SaldoRestanteConverter.cs
+++ b/Converters/SaldoRestanteConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+using DelCorp.Models;
+
+namespace DelCorp.Converters
+{
+    public class SaldoRestanteConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Presupuesto presupuesto)
+            {
+                var total = presupuesto.TotalPresupuesto ?? 0m;
+                var spent = presupuesto.MontoEjePresupuesto ?? 0m;
+                return total - spent;
+            }
+            return 0m;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ViewModels/PresupuestoViewModel.cs
+++ b/ViewModels/PresupuestoViewModel.cs
@@ -92,6 +92,7 @@ namespace DelCorp.ViewModels
                 }
                 foreach (var item in paged)
                 {
+                    item.MontoEjePresupuesto = await _dataService.GetTotalEjecutadoForPresupuestoAsync(item.Id);
                     if (!Presupuestos.Any(p => p.Id == item.Id))
                         Presupuestos.Add(item);
                 }

--- a/ViewModels/ProjectDetailViewModel.cs
+++ b/ViewModels/ProjectDetailViewModel.cs
@@ -118,6 +118,7 @@ public partial class ProjectDetailViewModel : ObservableObject, IQueryAttributab
             {
                 foreach (var presupuesto in presupuestosList)
                 {
+                    presupuesto.MontoEjePresupuesto = await _dataService.GetTotalEjecutadoForPresupuestoAsync(presupuesto.Id);
                     Presupuestos.Add(presupuesto);
                 }
             }

--- a/Views/PresupuestoPage.xaml
+++ b/Views/PresupuestoPage.xaml
@@ -3,10 +3,19 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodel="clr-namespace:DelCorp.ViewModels"
              xmlns:model="clr-namespace:DelCorp.Models"
+             xmlns:converters="clr-namespace:DelCorp.Converters"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="DelCorp.Views.PresupuestoPage"
              Title="Presupuestos"
              x:DataType="viewmodel:PresupuestoViewModel">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:BudgetProgressConverter x:Key="BudgetProgressConverter" />
+            <converters:SaldoRestanteConverter x:Key="SaldoRestanteConverter" />
+            <converters:GastoToColorConverter x:Key="GastoToColorConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
 
     <ContentPage.Behaviors>
         <toolkit:EventToCommandBehavior Command="{Binding RefreshPresupuestosCommand}" EventName="Appearing" />
@@ -38,51 +47,33 @@
 
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="model:Presupuesto">
-                    <Frame
-                        BorderColor="LightGray"
-                        Margin="0,5"
-                        Padding="15">
-                        <Grid RowDefinitions="Auto,Auto,Auto">
+                    <Frame Padding="10" Margin="10,5" CornerRadius="10" BorderColor="LightGray">
+                        <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto">
                             <Grid.GestureRecognizers>
-                                <TapGestureRecognizer 
+                                <TapGestureRecognizer
                                     Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodel:PresupuestoViewModel}}, Path=NavigateToPresupuestoDetailsCommand}"
                                     CommandParameter="{Binding .}" />
                             </Grid.GestureRecognizers>
-                            <Label 
-                                Grid.Row="0"
-                                Style="{StaticResource TitleSmall}"
-                                Text="{Binding NombrePresupuesto}" />
-                            <Grid 
-                                Grid.Row="1" 
-                                ColumnDefinitions="*,*" 
-                                Margin="0,10,0,0">
-                                                    
-                                    <StackLayout Grid.Column="0">
-                                        <Label Style="{StaticResource LabelSmall}" Text="Fecha Inicio" />
-                                        <Label Text="{Binding FechaInicioPresupuesto, StringFormat='{0:dd/MM/yyyy}'}"
-                                               Style="{StaticResource BodySmall}" />
-                                    </StackLayout>
-                                    <StackLayout Grid.Column="1">
-                                        <Label Style="{StaticResource LabelSmall}" Text="Fecha Fin"/>
-                                        <Label Text="{Binding FechaFinPresupuesto, StringFormat='{0:dd/MM/yyyy}'}"
-                                               Style="{StaticResource BodySmall}" />
-                                    </StackLayout>  
-                            </Grid>
-                            <Grid Grid.Row="2" ColumnDefinitions="*,*,*"
-                                  Margin="0,10,0,0">
-                                <StackLayout Grid.Column="0">
-                                    <Label Style="{StaticResource LabelSmall}" Text="Total" />
-                                    <Label Text="{Binding TotalPresupuesto, StringFormat='C$ {0:N2}'}" Style="{StaticResource BodySmall}" />
-                                </StackLayout>
-                                <StackLayout Grid.Column="1">
-                                    <Label Style="{StaticResource LabelSmall}" Text="Ejecutado" />
-                                    <Label Text="{Binding MontoEjePresupuesto, StringFormat='C$ {0:N2}'}" Style="{StaticResource BodySmall}" />
-                                </StackLayout>
-                                <StackLayout Grid.Column="2">
-                                    <Label Style="{StaticResource LabelSmall}" Text="Progreso" />
-                                    <Label Text="{Binding ProgresoPresupuesto, StringFormat='{0:P0}'}" Style="{StaticResource BodySmall}" />
-                                </StackLayout>
-                            </Grid>
+
+                            <Label Grid.Row="0" Grid.Column="0" Text="{Binding NombrePresupuesto}" FontSize="Medium" FontAttributes="Bold" />
+                            <Label Grid.Row="0" Grid.Column="1" Text="{Binding Id, StringFormat='ID: {0}'}" FontSize="Small" />
+
+                            <HorizontalStackLayout Grid.Row="1" Grid.ColumnSpan="2" Margin="0,5">
+                                <Label Text="Presupuesto: " FontAttributes="Bold" />
+                                <Label Text="{Binding TotalPresupuesto, StringFormat='{0:C}'}" />
+                                <Label Text=" | Gastado: " FontAttributes="Bold" Margin="10,0,0,0" />
+                                <Label Text="{Binding MontoEjePresupuesto, StringFormat='{0:C}'}"
+                                       TextColor="{Binding ., Converter={StaticResource GastoToColorConverter}}" />
+                            </HorizontalStackLayout>
+
+                            <ProgressBar Grid.Row="2" Grid.ColumnSpan="2"
+                                         Progress="{Binding ., Converter={StaticResource BudgetProgressConverter}}"
+                                         ProgressColor="MediumBlue" />
+
+                            <HorizontalStackLayout Grid.Row="3" Grid.ColumnSpan="2" Margin="0,5">
+                                <Label Text="Saldo: " FontAttributes="Bold" />
+                                <Label Text="{Binding ., Converter={StaticResource SaldoRestanteConverter}, StringFormat='{0:C}'}" />
+                            </HorizontalStackLayout>
                         </Grid>
                     </Frame>
                 </DataTemplate>

--- a/Views/ProjectDetailPage.xaml
+++ b/Views/ProjectDetailPage.xaml
@@ -3,8 +3,17 @@
              x:Class="DelCorp.Views.ProjectDetailPage"
              xmlns:viewmodel="clr-namespace:DelCorp.ViewModels"
              xmlns:models="clr-namespace:DelCorp.Models"
+             xmlns:converters="clr-namespace:DelCorp.Converters"
              Title="Detalles del Proyecto"
              x:DataType="viewmodel:ProjectDetailViewModel">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:BudgetProgressConverter x:Key="BudgetProgressConverter" />
+            <converters:SaldoRestanteConverter x:Key="SaldoRestanteConverter" />
+            <converters:GastoToColorConverter x:Key="GastoToColorConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
 
     <ScrollView>
         <VerticalStackLayout Spacing="15" Padding="20">
@@ -97,30 +106,27 @@
 
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="models:Presupuesto">
-                        <Frame Margin="0,5" Padding="10" BorderColor="LightGray">
-                            <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*,Auto">
-                                <Label 
-                                    Grid.Row="0" Grid.Column="0"
-                                    Text="{Binding NombrePresupuesto}" 
-                                    FontAttributes="Bold"/>
+                        <Frame Padding="10" Margin="10,5" CornerRadius="10" BorderColor="LightGray">
+                            <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="*,Auto">
+                                <Label Grid.Row="0" Grid.Column="0" Text="{Binding NombrePresupuesto}" FontSize="Medium" FontAttributes="Bold" />
+                                <Label Grid.Row="0" Grid.Column="1" Text="{Binding Id, StringFormat='ID: {0}'}" FontSize="Small" />
 
-                                <Label 
-                                    Grid.Row="1" Grid.Column="0"
-                                    Text="Total Presupuesto:" 
-                                    FontSize="12"/>
-                                <Label 
-                                    Grid.Row="1" Grid.Column="1"
-                                    Text="{Binding TotalPresupuesto, StringFormat='C${0:N2}'}" 
-                                    FontAttributes="Bold"/>
+                                <HorizontalStackLayout Grid.Row="1" Grid.ColumnSpan="2" Margin="0,5">
+                                    <Label Text="Presupuesto: " FontAttributes="Bold" />
+                                    <Label Text="{Binding TotalPresupuesto, StringFormat='{0:C}'}" />
+                                    <Label Text=" | Gastado: " FontAttributes="Bold" Margin="10,0,0,0" />
+                                    <Label Text="{Binding MontoEjePresupuesto, StringFormat='{0:C}'}"
+                                           TextColor="{Binding ., Converter={StaticResource GastoToColorConverter}}" />
+                                </HorizontalStackLayout>
 
-                                <Label 
-                                    Grid.Row="2" Grid.Column="0"
-                                    Text="Progreso:" 
-                                    FontSize="12"/>
-                                <Label 
-                                    Grid.Row="2" Grid.Column="1"
-                                    Text="{Binding ProgresoPresupuesto, StringFormat='{0:P0}'}" 
-                                    TextColor="{StaticResource Primary}"/>
+                                <ProgressBar Grid.Row="2" Grid.ColumnSpan="2"
+                                             Progress="{Binding ., Converter={StaticResource BudgetProgressConverter}}"
+                                             ProgressColor="MediumBlue" />
+
+                                <HorizontalStackLayout Grid.Row="3" Grid.ColumnSpan="2" Margin="0,5">
+                                    <Label Text="Saldo: " FontAttributes="Bold" />
+                                    <Label Text="{Binding ., Converter={StaticResource SaldoRestanteConverter}, StringFormat='{0:C}'}" />
+                                </HorizontalStackLayout>
                             </Grid>
                         </Frame>
                     </DataTemplate>

--- a/Views/RegistrarEtapaPage.xaml
+++ b/Views/RegistrarEtapaPage.xaml
@@ -9,11 +9,36 @@
     <ContentPage.Resources>
         <ResourceDictionary>
             <converters:InverseBoolConverter x:Key="InverseBoolConverter" />
+            <converters:BudgetProgressConverter x:Key="BudgetProgressConverter" />
+            <converters:SaldoRestanteConverter x:Key="SaldoRestanteConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
 
     <ScrollView>
         <VerticalStackLayout Spacing="10" Padding="20">
+
+            <Frame Padding="15" Margin="10" CornerRadius="10" BorderColor="CornflowerBlue">
+                <VerticalStackLayout>
+                    <Label Text="{Binding CurrentPresupuesto.NombrePresupuesto}" FontSize="Title" FontAttributes="Bold" />
+
+                    <HorizontalStackLayout Margin="0,10">
+                        <Label Text="Presupuesto Total:" FontAttributes="Bold" />
+                        <Label Text="{Binding CurrentPresupuesto.TotalPresupuesto, StringFormat=' {0:C}'}" />
+                    </HorizontalStackLayout>
+
+                    <HorizontalStackLayout>
+                        <Label Text="Total Gastado:" FontAttributes="Bold" />
+                        <Label Text="{Binding CurrentPresupuesto.MontoEjePresupuesto, StringFormat=' {0:C}'}" />
+                    </HorizontalStackLayout>
+
+                    <ProgressBar Progress="{Binding CurrentPresupuesto, Converter={StaticResource BudgetProgressConverter}}" Margin="0,10,0,0" />
+
+                    <HorizontalStackLayout Margin="0,5,0,0">
+                        <Label Text="Saldo Restante:" FontAttributes="Bold" />
+                        <Label Text="{Binding CurrentPresupuesto, Converter={StaticResource SaldoRestanteConverter}, StringFormat=' {0:C}'}" />
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </Frame>
 
             <Label Text="Registrar Nueva Etapa" FontAttributes="Bold" FontSize="Medium"/>
 


### PR DESCRIPTION
## Summary
- create converters for budget progress, remaining balance and spending color
- show budget totals and progress bars in Presupuesto list and project details
- display current budget summary in RegistrarEtapa page
- compute executed totals when loading budgets

## Testing
- `dotnet build -c Release` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a35cd928832ba926df6fdcc23d74