### PR TITLE
Fix budget spent total

### DIFF
--- a/Services/OfflineFirstDataService.cs
+++ b/Services/OfflineFirstDataService.cs
@@ -805,6 +805,7 @@ namespace DelCorp.Services
                                 updatedLocal.IsSynced = true;
                                 await _localDatabase.SavePresupuestoAsync(updatedLocal);
                             }
+                            remoteDto.MontoEjePresupuesto = await GetTotalEjecutadoForPresupuestoAsync(remoteDto.Id);
                             return remoteDto;
                         }
                     }
@@ -818,7 +819,13 @@ namespace DelCorp.Services
                     }
                 }
 
-                return localPresupuesto?.ToDto();
+                if (localPresupuesto != null)
+                {
+                    var dto = localPresupuesto.ToDto();
+                    dto.MontoEjePresupuesto = await GetTotalEjecutadoForPresupuestoAsync(dto.Id);
+                    return dto;
+                }
+                return null;
             }
             catch (Exception ex)
             {

--- a/ViewModels/EditPresupuestoViewModel.cs
+++ b/ViewModels/EditPresupuestoViewModel.cs
@@ -30,6 +30,10 @@ namespace DelCorp.ViewModels
             {
                 IsLoading = true;
                 PresupuestoToEdit = await _dataService.GetPresupuestoByIdAsync(value);
+                if (PresupuestoToEdit != null)
+                {
+                    PresupuestoToEdit.MontoEjePresupuesto = await _dataService.GetTotalEjecutadoForPresupuestoAsync(PresupuestoToEdit.Id);
+                }
                 IsLoading = false;
             }
         }

--- a/ViewModels/RegistrarEtapaViewModel.cs
+++ b/ViewModels/RegistrarEtapaViewModel.cs
@@ -99,6 +99,10 @@ public partial class RegistrarEtapaViewModel : ObservableObject, IQueryAttributa
         IdPresupuesto = presupuestoId;
         Debug.WriteLine($"[RegistrarEtapaVM] Inicializando con IdPresupuesto: {IdPresupuesto}");
         CurrentPresupuesto = await _dataService.GetPresupuestoByIdAsync(presupuestoId);
+        if (CurrentPresupuesto != null)
+        {
+            CurrentPresupuesto.MontoEjePresupuesto = await _dataService.GetTotalEjecutadoForPresupuestoAsync(CurrentPresupuesto.Id);
+        }
         SetIsBusy(true);
         try
         {


### PR DESCRIPTION
## Summary
- compute executed total when fetching single presupuesto
- show executed total in edit and etapa views

## Testing
- `dotnet test DelCorp.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a69a979c832b9c4caa1e9ae1e2d6